### PR TITLE
Enable logging in unit/integration tests

### DIFF
--- a/s3/build.gradle
+++ b/s3/build.gradle
@@ -30,18 +30,13 @@ dependencies {
     runtimeOnly "com.github.luben:zstd-jni:1.5.4-2"
     testImplementation 'org.mockito:mockito-core:5.1.1'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.1.1'
+    testRuntimeOnly "org.slf4j:slf4j-log4j12:1.7.36"
     integrationTestImplementation "org.testcontainers:localstack:$testcontainersVersion"
 }
 
 sourceSets {
     integrationTest {
-        java {
-            srcDirs = ['src/integration-test/java']
-        }
-        resources {
-            srcDirs = ['src/integration-test/resources']
-        }
-
+        java.srcDirs = ['src/integration-test/java']
         compileClasspath += sourceSets.main.output + configurations.testRuntimeClasspath
         runtimeClasspath += output + compileClasspath
     }

--- a/s3/src/main/resources/log4j.properties
+++ b/s3/src/main/resources/log4j.properties
@@ -1,0 +1,21 @@
+#
+# Copyright 2023 Aiven Oy
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n


### PR DESCRIPTION
Adding log4j configuration and slf4j-log4j12 dependency to enable logging in unit and integration tests.