### PR TITLE
Add object storage interfaces and file system implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,7 @@ subprojects {
         compileOnly "org.slf4j:slf4j-api:1.7.36"
         implementation "org.bouncycastle:bcprov-jdk15on:1.70"
         testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
+        testRuntimeOnly "org.slf4j:slf4j-log4j12:1.7.36"
         testImplementation group: "org.apache.kafka", name: "kafka-storage-api", version: kafkaVersion
         testImplementation group: "org.apache.kafka", name: "kafka-clients", version: kafkaVersion
         testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"

--- a/commons/src/main/java/io/aiven/kafka/tiered/storage/commons/storage/FileDeleter.java
+++ b/commons/src/main/java/io/aiven/kafka/tiered/storage/commons/storage/FileDeleter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Aiven Oy
+ * Copyright 2023 Aiven Oy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,10 @@
  * limitations under the License.
  */
 
-ext {
-    zstdVersion = "1.5.4-2"
-}
+package io.aiven.kafka.tiered.storage.commons.storage;
 
-dependencies {
-    // The client of a library should provide a runtime dependency. For now taking the version from kafka-storage-api
-    compileOnly 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
-    // The client of a library should provide a runtime dependency.
-    // For now taking the version from kafka-clients
-    compileOnly "com.github.luben:zstd-jni:$zstdVersion"
-    testImplementation "com.github.luben:zstd-jni:$zstdVersion"
-    implementation "commons-io:commons-io:2.11.0"
+import java.io.IOException;
+
+public interface FileDeleter {
+    void delete(String key) throws IOException;
 }

--- a/commons/src/main/java/io/aiven/kafka/tiered/storage/commons/storage/FileFetcher.java
+++ b/commons/src/main/java/io/aiven/kafka/tiered/storage/commons/storage/FileFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Aiven Oy
+ * Copyright 2023 Aiven Oy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,23 @@
  * limitations under the License.
  */
 
-ext {
-    zstdVersion = "1.5.4-2"
-}
+package io.aiven.kafka.tiered.storage.commons.storage;
 
-dependencies {
-    // The client of a library should provide a runtime dependency. For now taking the version from kafka-storage-api
-    compileOnly 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
-    // The client of a library should provide a runtime dependency.
-    // For now taking the version from kafka-clients
-    compileOnly "com.github.luben:zstd-jni:$zstdVersion"
-    testImplementation "com.github.luben:zstd-jni:$zstdVersion"
-    implementation "commons-io:commons-io:2.11.0"
+import java.io.IOException;
+import java.io.InputStream;
+
+public interface FileFetcher {
+    /**
+     * Fetch file.
+     * @param key file key.
+     */
+    InputStream fetch(String key) throws IOException;
+
+    /**
+     * Fetch file.
+     * @param key file key.
+     * @param from start position, inclusive.
+     * @param to end position, inclusive.
+     */
+    InputStream fetch(String key, int from, int to) throws IOException;
 }

--- a/commons/src/main/java/io/aiven/kafka/tiered/storage/commons/storage/FileUploader.java
+++ b/commons/src/main/java/io/aiven/kafka/tiered/storage/commons/storage/FileUploader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Aiven Oy
+ * Copyright 2023 Aiven Oy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,11 @@
  * limitations under the License.
  */
 
-ext {
-    zstdVersion = "1.5.4-2"
-}
+package io.aiven.kafka.tiered.storage.commons.storage;
 
-dependencies {
-    // The client of a library should provide a runtime dependency. For now taking the version from kafka-storage-api
-    compileOnly 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
-    // The client of a library should provide a runtime dependency.
-    // For now taking the version from kafka-clients
-    compileOnly "com.github.luben:zstd-jni:$zstdVersion"
-    testImplementation "com.github.luben:zstd-jni:$zstdVersion"
-    implementation "commons-io:commons-io:2.11.0"
+import java.io.IOException;
+import java.io.InputStream;
+
+public interface FileUploader {
+    void upload(InputStream inputStream, String key) throws IOException;
 }

--- a/commons/src/main/java/io/aiven/kafka/tiered/storage/commons/storage/ObjectStorageFactory.java
+++ b/commons/src/main/java/io/aiven/kafka/tiered/storage/commons/storage/ObjectStorageFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Aiven Oy
+ * Copyright 2023 Aiven Oy
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-ext {
-    zstdVersion = "1.5.4-2"
-}
+package io.aiven.kafka.tiered.storage.commons.storage;
 
-dependencies {
-    // The client of a library should provide a runtime dependency. For now taking the version from kafka-storage-api
-    compileOnly 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
-    // The client of a library should provide a runtime dependency.
-    // For now taking the version from kafka-clients
-    compileOnly "com.github.luben:zstd-jni:$zstdVersion"
-    testImplementation "com.github.luben:zstd-jni:$zstdVersion"
-    implementation "commons-io:commons-io:2.11.0"
+import org.apache.kafka.common.Configurable;
+
+public interface ObjectStorageFactory extends Configurable {
+    FileUploader fileUploader();
+
+    FileFetcher fileFetcher();
+
+    FileDeleter fileDeleter();
 }

--- a/commons/src/main/java/io/aiven/kafka/tiered/storage/commons/storage/filesystem/FileSystemStorage.java
+++ b/commons/src/main/java/io/aiven/kafka/tiered/storage/commons/storage/filesystem/FileSystemStorage.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tiered.storage.commons.storage.filesystem;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import io.aiven.kafka.tiered.storage.commons.storage.FileDeleter;
+import io.aiven.kafka.tiered.storage.commons.storage.FileFetcher;
+import io.aiven.kafka.tiered.storage.commons.storage.FileUploader;
+
+import org.apache.commons.io.input.BoundedInputStream;
+
+class FileSystemStorage implements FileUploader, FileFetcher, FileDeleter {
+    private final String fsRoot;
+    private final boolean overwrites;
+
+    FileSystemStorage(final String fsRoot, final boolean overwrites) {
+        this.fsRoot = fsRoot;
+        this.overwrites = overwrites;
+    }
+
+    @Override
+    public void upload(final InputStream inputStream, final String key) throws IOException {
+        final Path path = Path.of(fsRoot, key);
+        if (!overwrites && Files.exists(path)) {
+            throw new IOException("File " + path + " already exists");
+        }
+        Files.createDirectories(path.getParent());
+        try (final OutputStream outputStream = Files.newOutputStream(path)) {
+            inputStream.transferTo(outputStream);
+        }
+    }
+
+    @Override
+    public InputStream fetch(final String key) throws IOException {
+        final Path path = Path.of(fsRoot, key);
+        return Files.newInputStream(path);
+    }
+
+    @Override
+    public InputStream fetch(final String key, final int from, final int to) throws IOException {
+        if (from < 0) {
+            throw new IllegalArgumentException("from cannot be negative, " + from + " given");
+        }
+        if (from > to) {
+            throw new IllegalArgumentException("from cannot be more than to, from=" + from + ", to=" + to + " given");
+        }
+
+        final Path path = Path.of(fsRoot, key);
+        final long fileSize = Files.size(path);
+        if (to > fileSize) {
+            throw new IllegalArgumentException("to cannot be bigger than file size, to="
+                + to + ", file size=" + fileSize + " given");
+        }
+        final InputStream result = new BoundedInputStream(Files.newInputStream(path), to + 1);
+        result.skip(from);
+        return result;
+    }
+
+    @Override
+    public void delete(final String key) throws IOException {
+        Files.delete(Path.of(fsRoot, key));
+    }
+}

--- a/commons/src/main/java/io/aiven/kafka/tiered/storage/commons/storage/filesystem/FileSystemStorageConfig.java
+++ b/commons/src/main/java/io/aiven/kafka/tiered/storage/commons/storage/filesystem/FileSystemStorageConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tiered.storage.commons.storage.filesystem;
+
+import java.util.Map;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+class FileSystemStorageConfig extends AbstractConfig {
+    private static final ConfigDef CONFIG;
+
+    private static final String ROOT_CONFIG = "root";
+    private static final String ROOT_DOC = "Root directory";
+
+    private static final String OVERWRITE_ENABLED_CONFIG = "overwrite.enabled";
+    private static final String OVERWRITE_ENABLED_DOC = "Enable overwriting existing files";
+
+    static {
+        CONFIG = new ConfigDef();
+        CONFIG.define(
+            ROOT_CONFIG,
+            ConfigDef.Type.STRING,
+            ConfigDef.NO_DEFAULT_VALUE,
+            ConfigDef.Importance.HIGH,
+            ROOT_DOC
+        );
+        CONFIG.define(
+            OVERWRITE_ENABLED_CONFIG,
+            ConfigDef.Type.BOOLEAN,
+            false,
+            ConfigDef.Importance.MEDIUM,
+            OVERWRITE_ENABLED_DOC
+        );
+    }
+
+    FileSystemStorageConfig(final Map<String, ?> props) {
+        super(CONFIG, props);
+    }
+
+    final String root() {
+        return getString(ROOT_CONFIG);
+    }
+
+    final boolean overwrites() {
+        return getBoolean(OVERWRITE_ENABLED_CONFIG);
+    }
+}

--- a/commons/src/main/java/io/aiven/kafka/tiered/storage/commons/storage/filesystem/FileSystemStorageFactory.java
+++ b/commons/src/main/java/io/aiven/kafka/tiered/storage/commons/storage/filesystem/FileSystemStorageFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tiered.storage.commons.storage.filesystem;
+
+import java.util.Map;
+
+import io.aiven.kafka.tiered.storage.commons.storage.FileDeleter;
+import io.aiven.kafka.tiered.storage.commons.storage.FileFetcher;
+import io.aiven.kafka.tiered.storage.commons.storage.FileUploader;
+import io.aiven.kafka.tiered.storage.commons.storage.ObjectStorageFactory;
+
+public class FileSystemStorageFactory implements ObjectStorageFactory {
+    private String root;
+    private boolean overwrites;
+
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        final FileSystemStorageConfig config = new FileSystemStorageConfig(configs);
+        this.root = config.root();
+        this.overwrites = config.overwrites();
+    }
+
+    @Override
+    public FileUploader fileUploader() {
+        return new FileSystemStorage(root, overwrites);
+    }
+
+    @Override
+    public FileFetcher fileFetcher() {
+        return new FileSystemStorage(root, overwrites);
+    }
+
+    @Override
+    public FileDeleter fileDeleter() {
+        return new FileSystemStorage(root, overwrites);
+    }
+}

--- a/commons/src/test/java/io/aiven/kafka/tiered/storage/commons/storage/filesystem/FileSystemStorageConfigTest.java
+++ b/commons/src/test/java/io/aiven/kafka/tiered/storage/commons/storage/filesystem/FileSystemStorageConfigTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tiered.storage.commons.storage.filesystem;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FileSystemStorageConfigTest {
+    @Test
+    void minimalConfig() {
+        final FileSystemStorageConfig config = new FileSystemStorageConfig(Map.of(
+            "root", "."
+        ));
+        assertThat(config.root()).isEqualTo(".");
+        assertThat(config.overwrites()).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void overwriteEnabledExplicit(final boolean overwriteEnabled) {
+        final FileSystemStorageConfig config = new FileSystemStorageConfig(Map.of(
+            "root", ".",
+            "overwrite.enabled", Boolean.toString(overwriteEnabled)
+        ));
+        assertThat(config.overwrites()).isEqualTo(overwriteEnabled);
+    }
+}

--- a/commons/src/test/java/io/aiven/kafka/tiered/storage/commons/storage/filesystem/FileSystemStorageFactoryTest.java
+++ b/commons/src/test/java/io/aiven/kafka/tiered/storage/commons/storage/filesystem/FileSystemStorageFactoryTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tiered.storage.commons.storage.filesystem;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import io.aiven.kafka.tiered.storage.commons.storage.ObjectStorageFactory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FileSystemStorageFactoryTest {
+    @Test
+    void testNotAllowOverwriting(@TempDir final Path tempDir) throws IOException {
+        final File fsRoot = tempDir.toFile();
+        final ObjectStorageFactory osFactory = new FileSystemStorageFactory();
+        osFactory.configure(Map.of(
+            "root", fsRoot.toString(),
+            "overwrite.enabled", "false"
+        ));
+
+        final InputStream logFile = new ByteArrayInputStream("log file".getBytes());
+        osFactory.fileUploader().upload(logFile, "aaa/0.log.txt");
+
+        assertThatThrownBy(() -> osFactory.fileUploader().upload(logFile, "aaa/0.log.txt"))
+            .isInstanceOf(IOException.class)
+            .hasMessage("File %s already exists", fsRoot + "/aaa/0.log.txt");
+    }
+
+    @Test
+    void testAllowOverwriting(@TempDir final Path tempDir) throws IOException {
+        final File fsRoot = tempDir.toFile();
+        final ObjectStorageFactory osFactory = new FileSystemStorageFactory();
+        osFactory.configure(Map.of(
+            "root", fsRoot.toString(),
+            "overwrite.enabled", "true"
+        ));
+
+        final byte[] data1 = "log file 1".getBytes();
+        osFactory.fileUploader().upload(new ByteArrayInputStream(data1), "aaa/0.log.txt");
+        assertThat(Files.readAllBytes(Path.of(fsRoot.getPath(), "aaa/0.log.txt")))
+            .isEqualTo(data1);
+
+        final byte[] data2 = "log file 2".getBytes();
+        assertThatNoException().isThrownBy(
+            () -> osFactory.fileUploader().upload(new ByteArrayInputStream(data2), "aaa/0.log.txt"));
+        assertThat(Files.readAllBytes(Path.of(fsRoot.getPath(), "aaa/0.log.txt")))
+            .isEqualTo(data2);
+    }
+
+    @Test
+    void testUploadFetchDelete(@TempDir final Path tempDir) throws IOException {
+        final File fsRoot = tempDir.toFile();
+        final ObjectStorageFactory osFactory = new FileSystemStorageFactory();
+        osFactory.configure(Map.of(
+            "root", fsRoot.toString()
+        ));
+
+        final byte[] data = "some file".getBytes();
+        final InputStream file = new ByteArrayInputStream(data);
+        osFactory.fileUploader().upload(file, "aaa/0.log.txt");
+
+        try (final InputStream fetch = osFactory.fileFetcher().fetch("aaa/0.log.txt")) {
+            final String r = new String(fetch.readAllBytes());
+            assertThat(r).isEqualTo("some file");
+        }
+
+        try (final InputStream fetch = osFactory.fileFetcher().fetch("aaa/0.log.txt", 1, data.length - 2)) {
+            final String r = new String(fetch.readAllBytes());
+            assertThat(r).isEqualTo("ome fil");
+        }
+
+        osFactory.fileDeleter().delete("aaa/0.log.txt");
+
+        assertThat(new File(fsRoot, "aaa")).isEmptyDirectory();
+    }
+}

--- a/commons/src/test/resources/log4j.properties
+++ b/commons/src/test/resources/log4j.properties
@@ -1,0 +1,21 @@
+#
+# Copyright 2023 Aiven Oy
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n


### PR DESCRIPTION
These interfaces are mainly supposed to be implemented with S3, GCS, and other object storage implementations, which are to be done. The file system implementation is mostly for testing.

To put this in the future context, the plugin will instantiate concrete implementations of `ObjectStorageFactory`, which will be S3, GCS, and others.
