### PR TITLE
chore: introduce docker playground for tiered-storage

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -2,6 +2,8 @@
 
 Docker compose environment to try out tiered storage plugins.
 
+> NOTE: Consider this playground environments unstable until future releases.
+
 ## Structure
 
 - A [docker image](./kafka/Dockerfile) is built from a Kafka repository branch

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,106 @@
+# Docker playground
+
+Docker compose environment to try out tiered storage plugins.
+
+## Structure
+
+- A [docker image](./kafka/Dockerfile) is built from a Kafka repository branch
+- Each plugin will have a Docker compose, e.g. [S3](./s3/compose.yml), to start an environment with Kafka, Zookeeper, plugin setup, and dependencies.
+
+## How to use
+
+### S3
+
+> on [./s3](./s3) directory
+
+Build plugin before starting Docker compose:
+
+On root directory:
+
+```shell
+./gradlew clean s3:installDist
+```
+
+`compose.yml` is mounting the distribution directory:
+
+```yaml
+kafka:
+  # ...
+  volumes:
+    - ./../../s3/build/install/s3:/kafka/plugins/tiered-storage-s3
+```
+
+and then:
+
+```shell
+docker-compose up -d
+```
+
+#### Connect to AWS S3
+
+Set AWS credentials on `.env` file:
+
+```properties .env
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+```
+
+and use variables on `compose.yml`:
+
+```yaml
+  kafka:
+    # ...
+    volumes:
+      # ...
+      - ./private.pem:/kafka/plugins/private.pem
+      - ./public.pem:/kafka/plugins/public.pem
+    command:
+      - kafka-server-start.sh
+      - config/server.properties
+      # ...
+      - --override
+      - rsm.config.s3.client.aws_access_key_id=${AWS_ACCESS_KEY_ID}
+      - --override
+      - rsm.config.s3.client.aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+```
+
+#### Using Encryption mechanisms
+
+Generate RSA key pair:
+
+```shell
+make rsa-keys
+```
+
+and set paths on `compose.yml` file:
+
+```yaml
+  kafka:
+    # ...
+    volumes:
+      # ...
+      - ./private.pem:/kafka/plugins/private.pem
+      - ./public.pem:/kafka/plugins/public.pem
+    command:
+      - kafka-server-start.sh
+      - config/server.properties
+      # ...
+      - --override
+      - rsm.config.s3.public_key_pem=/kafka/plugins/public.pem
+      - --override
+      - rsm.config.s3.private_key_pem=/kafka/plugins/private.pem
+      # ...
+```
+
+
+### Kafka
+
+Creating topics with Tiered storage:
+
+```shell
+make topic
+```
+
+creates a topic t1 with 6 partitions, 10MB segments, retention bytes 100MB, and 20MB local retention.
+
+

--- a/docker/kafka/Dockerfile
+++ b/docker/kafka/Dockerfile
@@ -1,0 +1,28 @@
+FROM fedora:37 AS base
+
+ENV JAVA_VERSION 17
+RUN dnf install -y java-${JAVA_VERSION}-openjdk-devel git
+
+ENV JAVA_HOME /usr/lib/jvm/java-${JAVA_VERSION}-openjdk
+ARG AK_REPO=https://github.com/apache/kafka
+ARG AK_BRANCH=3.4
+
+RUN git clone ${AK_REPO}
+
+WORKDIR /kafka
+RUN git checkout ${AK_BRANCH}
+
+RUN ./gradlew releaseTarGz
+
+FROM eclipse-temurin:17-jre AS kafka
+
+ENV SCALA_VERSION 2.13
+ARG KAFKA_VERSION=3.4.1-SNAPSHOT
+
+COPY --from=base /kafka/core/build/distributions/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz ./kafka.tgz
+RUN tar xf kafka.tgz; mv /kafka_${SCALA_VERSION}-${KAFKA_VERSION} /kafka
+
+ENV KAFKA_HOME /kafka
+WORKDIR ${KAFKA_HOME}
+ENV PATH $PATH:${KAFKA_HOME}/bin
+CMD [ "kafka-server-start.sh" ]

--- a/docker/s3/.gitignore
+++ b/docker/s3/.gitignore
@@ -1,0 +1,8 @@
+# Credentials
+.env
+
+# Demo keys
+*.pem
+
+# Backend volumes
+minio/

--- a/docker/s3/Makefile
+++ b/docker/s3/Makefile
@@ -1,0 +1,23 @@
+all: build up
+
+build:
+	docker compose build
+
+up:
+	docker compose up -d
+
+# Generate keys for S3 plugin
+rsa-keys:
+	openssl genrsa -out private.pem 512
+	openssl rsa -in private.pem -outform PEM -out public.pem -pubout
+
+topic:
+	${KAFKA_HOME}/bin/kafka-topics.sh \
+		--bootstrap-server localhost:9092 \
+		--create \
+		--config segment.bytes=1000000 \
+		--config retention.bytes=100000000 \
+		--config remote.storage.enable=true \
+		--config local.retention.bytes=2000000 \
+		--partitions 6 \
+		--topic t1

--- a/docker/s3/compose.yml
+++ b/docker/s3/compose.yml
@@ -1,0 +1,94 @@
+version: '3.8'
+services:
+  zookeeper:
+    image: kafka
+    build:
+      context: ../kafka/.
+      args:
+        - AK_REPO=https://github.com/aiven/kafka
+        - AK_BRANCH=3.3-2022-10-06-tiered-storage
+        - KAFKA_VERSION=3.3.2-SNAPSHOT
+    command:
+      - zookeeper-server-start.sh
+      - config/zookeeper.properties
+
+  kafka:
+    image: kafka
+    build:
+      context: ../kafka/.
+      args:
+        - AK_REPO=https://github.com/aiven/kafka
+        - AK_BRANCH=3.3-2022-10-06-tiered-storage
+        - KAFKA_VERSION=3.3.2-SNAPSHOT
+    ports:
+      - "9092:9092"
+    volumes:
+      # mount plugin
+      - ./../../s3/build/install/s3:/kafka/plugins/tiered-storage-s3
+      # encryption keys
+      - ./private.pem:/kafka/plugins/private.pem
+      - ./public.pem:/kafka/plugins/public.pem
+    command:
+      - kafka-server-start.sh
+      - config/server.properties
+      - --override
+      - zookeeper.connect=zookeeper:2181
+      - --override
+      - listeners=BROKER://kafka:29092,EXTERNAL://kafka:9092
+      - --override
+      - advertised.listeners=BROKER://kafka:29092,EXTERNAL://localhost:9092
+      - --override
+      - listener.security.protocol.map=BROKER:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - --override
+      - inter.broker.listener.name=BROKER
+      # Enable Tiered storage
+      - --override
+      - remote.log.storage.system.enable=true
+      - --override
+      - remote.log.storage.manager.class.name=io.aiven.kafka.tiered.storage.s3.S3RemoteStorageManager
+      - --override
+      - remote.log.storage.manager.class.path=/kafka/plugins/tiered-storage-s3/*
+      - --override
+      - remote.log.metadata.manager.class.name=org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManager
+      # Tiered storage S3 plugin
+      - --override
+      - rsm.config.s3.bucket.name=kafka-ts-us-east-1
+      - --override
+      - rsm.config.s3.region=us-east-1
+      #- --override
+      #- rsm.config.s3.endpoint.url=http://minio:9090
+      - --override
+      - rsm.config.s3.credentials.provider.class=com.amazonaws.auth.AWSStaticCredentialsProvider
+      - --override
+      - rsm.config.s3.client.aws_access_key_id=${AWS_ACCESS_KEY_ID}
+      - --override
+      - rsm.config.s3.client.aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+      - --override
+      - rsm.config.s3.public_key_pem=/kafka/plugins/public.pem
+      - --override
+      - rsm.config.s3.private_key_pem=/kafka/plugins/private.pem
+      # Tiered Storage: RLMM config
+      - --override
+      - rlmm.config.remote.log.metadata.common.client.bootstrap.servers=kafka:29092
+      - --override
+      - rlmm.config.remote.log.metadata.topic.replication.factor=1
+
+  # Experimental services
+  localstack:
+    image: localstack/localstack:2.0.0
+    environment:
+      - SERVICES=s3
+    ports:
+      - "4566:4566"
+
+  minio:
+    image: quay.io/minio/minio
+    environment:
+      - MINIO_ROOT_USER=admin
+      - MINIO_ROOT_PASSWORD=password
+    ports:
+      - "9000:9000"
+      - "9090:9090"
+    volumes:
+      - ./minio/data:/data
+    command: server /data --console-address ":9090"


### PR DESCRIPTION
Adds a Docker playground to build Kafka from source-code and add plugins for testing purposes.
No guarantee to keep it stable just yet.

The goal is to iterate faster on how users would use the plugins in their environments.