### PR TITLE
feat: add custom S3 endpoint URL config

### DIFF
--- a/docker/s3/Makefile
+++ b/docker/s3/Makefile
@@ -15,9 +15,17 @@ topic:
 	${KAFKA_HOME}/bin/kafka-topics.sh \
 		--bootstrap-server localhost:9092 \
 		--create \
-		--config segment.bytes=1000000 \
-		--config retention.bytes=100000000 \
+		--config segment.bytes=10000000 \
+		--config retention.bytes=500000000 \
 		--config remote.storage.enable=true \
-		--config local.retention.bytes=2000000 \
+		--config local.retention.bytes=50000000 \
 		--partitions 6 \
 		--topic t1
+
+localstack: localstack_profile localstack_s3_bucket
+
+localstack_profile:
+	aws configure --profile localstack
+
+localstack_s3_bucket:
+	aws s3 --endpoint-url http://localhost:4566 --profile localstack mb s3://kafka-ts-v1

--- a/docker/s3/compose.yml
+++ b/docker/s3/compose.yml
@@ -52,11 +52,15 @@ services:
       - remote.log.metadata.manager.class.name=org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManager
       # Tiered storage S3 plugin
       - --override
-      - rsm.config.s3.bucket.name=kafka-ts-us-east-1
+      - rsm.config.s3.bucket.name=kafka-ts-v1
       - --override
       - rsm.config.s3.region=us-east-1
-      #- --override
-      #- rsm.config.s3.endpoint.url=http://minio:9090
+      # For Localstack
+      # - --override
+      # - rsm.config.s3.endpoint.url=http://localstack:4566
+      # For MinIO
+      - --override
+      - rsm.config.s3.endpoint.url=http://minio:9000
       - --override
       - rsm.config.s3.credentials.provider.class=com.amazonaws.auth.AWSStaticCredentialsProvider
       - --override
@@ -67,6 +71,10 @@ services:
       - rsm.config.s3.public_key_pem=/kafka/plugins/public.pem
       - --override
       - rsm.config.s3.private_key_pem=/kafka/plugins/private.pem
+      - --override
+      - rsm.config.s3.multipart.upload.part.size=5000000
+      - --override
+      - rsm.config.s3.upload.part.size=10000000
       # Tiered Storage: RLMM config
       - --override
       - rlmm.config.remote.log.metadata.common.client.bootstrap.servers=kafka:29092

--- a/s3/src/integration-test/java/io.aiven.kafka.tiered.storage.s3/S3RemoteStorageManagerTest.java
+++ b/s3/src/integration-test/java/io.aiven.kafka.tiered.storage.s3/S3RemoteStorageManagerTest.java
@@ -172,8 +172,10 @@ public class S3RemoteStorageManagerTest {
             LOCALSTACK.getEndpointOverride(LocalStackContainer.Service.S3).toString(),
             LOCALSTACK.getRegion()
         );
-        remoteStorageManager = new S3RemoteStorageManager(endpointConfiguration);
-        remoteStorageManager.configure(basicProps(bucket, s3PathPrefix));
+        remoteStorageManager = new S3RemoteStorageManager();
+        Map<String, String> configs = basicProps(bucket, s3PathPrefix);
+        configs.put(S3RemoteStorageManagerConfig.S3_ENDPOINT_URL_CONFIG, endpointConfiguration.getServiceEndpoint());
+        remoteStorageManager.configure(configs);
     }
 
     protected static void writePemFile(final Path path, final EncodedKeySpec encodedKeySpec) throws IOException {

--- a/s3/src/integration-test/java/io.aiven.kafka.tiered.storage.s3/S3RemoteStorageManagerTest.java
+++ b/s3/src/integration-test/java/io.aiven.kafka.tiered.storage.s3/S3RemoteStorageManagerTest.java
@@ -98,9 +98,9 @@ public class S3RemoteStorageManagerTest {
 
     static final String TOPIC = "connect-log";
     static final TopicIdPartition TP0 = new TopicIdPartition(Uuid.randomUuid(),
-            new TopicPartition(TOPIC, 0));
+        new TopicPartition(TOPIC, 0));
     static final TopicIdPartition TP1 = new TopicIdPartition(Uuid.randomUuid(),
-            new TopicPartition(TOPIC, 1));
+        new TopicPartition(TOPIC, 1));
 
     public static final String LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
     public static final String DIGITS = "0123456789";
@@ -133,7 +133,7 @@ public class S3RemoteStorageManagerTest {
 
     @BeforeAll
     public static void setUpClass(@TempDir final Path tmpFolder)
-            throws NoSuchAlgorithmException, NoSuchProviderException, IOException {
+        throws NoSuchAlgorithmException, NoSuchProviderException, IOException {
         s3Client = AmazonS3ClientBuilder
             .standard()
             .withEndpointConfiguration(
@@ -173,7 +173,7 @@ public class S3RemoteStorageManagerTest {
             LOCALSTACK.getRegion()
         );
         remoteStorageManager = new S3RemoteStorageManager();
-        Map<String, String> configs = basicProps(bucket, s3PathPrefix);
+        final Map<String, String> configs = basicProps(bucket, s3PathPrefix);
         configs.put(S3RemoteStorageManagerConfig.S3_ENDPOINT_URL_CONFIG, endpointConfiguration.getServiceEndpoint());
         remoteStorageManager.configure(configs);
     }
@@ -233,36 +233,36 @@ public class S3RemoteStorageManagerTest {
         final String baseLogFileName1 = segment1.log().file().getName();
         final String baseLogFileName2 = segment2.log().file().getName();
         assertThat(keys).containsExactlyInAnyOrder(
-                s3Key(TP0, uuid1 + "-" + baseLogFileName1) + "_0",
-                s3Key(TP0, uuid1 + "-" + baseLogFileName1) + "_1",
-                s3Key(TP0, uuid1 + "-" + baseLogFileName1) + "_2",
-                s3Key(TP0, uuid1 + "-" + baseLogFileName1) + "_3",
-                s3Key(TP0, uuid1 + "-" + filenamePrefixFromOffset(segment1.baseOffset()) + "."
-                        + RemoteStorageManager.IndexType.OFFSET),
-                s3Key(TP0, uuid1 + "-" + filenamePrefixFromOffset(segment1.baseOffset()) + "."
-                        + RemoteStorageManager.IndexType.TIMESTAMP),
-                s3Key(TP0, uuid1 + "-" + filenamePrefixFromOffset(segment1.baseOffset()) + "."
-                        + RemoteStorageManager.IndexType.PRODUCER_SNAPSHOT),
-                s3Key(TP0, uuid1 + "-" + filenamePrefixFromOffset(segment1.baseOffset()) + "."
-                        + RemoteStorageManager.IndexType.TRANSACTION),
-                s3Key(TP0, uuid1 + "-" + String.format("%020d", segment1.baseOffset()) + "."
-                        + RemoteStorageManager.IndexType.LEADER_EPOCH),
-                s3Key(TP0, uuid1 + "-" + String.format("%020d", segment1.baseOffset()) + ".metadata.json"),
-                s3Key(TP1, uuid2 + "-" + baseLogFileName2) + "_0",
-                s3Key(TP1, uuid2 + "-" + baseLogFileName2) + "_1",
-                s3Key(TP1, uuid2 + "-" + baseLogFileName2) + "_2",
-                s3Key(TP1, uuid2 + "-" + baseLogFileName2) + "_3",
-                s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
-                        + RemoteStorageManager.IndexType.OFFSET),
-                s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
-                        + RemoteStorageManager.IndexType.TIMESTAMP),
-                s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
-                        + RemoteStorageManager.IndexType.PRODUCER_SNAPSHOT),
-                s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
-                        + RemoteStorageManager.IndexType.TRANSACTION),
-                s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
-                        + RemoteStorageManager.IndexType.LEADER_EPOCH),
-                s3Key(TP1, uuid2 + "-" + String.format("%020d", segment2.baseOffset()) + ".metadata.json")
+            s3Key(TP0, uuid1 + "-" + baseLogFileName1) + "_0",
+            s3Key(TP0, uuid1 + "-" + baseLogFileName1) + "_1",
+            s3Key(TP0, uuid1 + "-" + baseLogFileName1) + "_2",
+            s3Key(TP0, uuid1 + "-" + baseLogFileName1) + "_3",
+            s3Key(TP0, uuid1 + "-" + filenamePrefixFromOffset(segment1.baseOffset()) + "."
+                + RemoteStorageManager.IndexType.OFFSET),
+            s3Key(TP0, uuid1 + "-" + filenamePrefixFromOffset(segment1.baseOffset()) + "."
+                + RemoteStorageManager.IndexType.TIMESTAMP),
+            s3Key(TP0, uuid1 + "-" + filenamePrefixFromOffset(segment1.baseOffset()) + "."
+                + RemoteStorageManager.IndexType.PRODUCER_SNAPSHOT),
+            s3Key(TP0, uuid1 + "-" + filenamePrefixFromOffset(segment1.baseOffset()) + "."
+                + RemoteStorageManager.IndexType.TRANSACTION),
+            s3Key(TP0, uuid1 + "-" + String.format("%020d", segment1.baseOffset()) + "."
+                + RemoteStorageManager.IndexType.LEADER_EPOCH),
+            s3Key(TP0, uuid1 + "-" + String.format("%020d", segment1.baseOffset()) + ".metadata.json"),
+            s3Key(TP1, uuid2 + "-" + baseLogFileName2) + "_0",
+            s3Key(TP1, uuid2 + "-" + baseLogFileName2) + "_1",
+            s3Key(TP1, uuid2 + "-" + baseLogFileName2) + "_2",
+            s3Key(TP1, uuid2 + "-" + baseLogFileName2) + "_3",
+            s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
+                + RemoteStorageManager.IndexType.OFFSET),
+            s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
+                + RemoteStorageManager.IndexType.TIMESTAMP),
+            s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
+                + RemoteStorageManager.IndexType.PRODUCER_SNAPSHOT),
+            s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
+                + RemoteStorageManager.IndexType.TRANSACTION),
+            s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
+                + RemoteStorageManager.IndexType.LEADER_EPOCH),
+            s3Key(TP1, uuid2 + "-" + String.format("%020d", segment2.baseOffset()) + ".metadata.json")
         );
     }
 
@@ -270,9 +270,9 @@ public class S3RemoteStorageManagerTest {
         final File file = Log.producerSnapshotFile(logDir, segment.baseOffset());
         file.createNewFile();
         return new LogSegmentData(segment.log().file().toPath(), segment.offsetIndex().file().toPath(),
-                segment.timeIndex().file().toPath(), Optional.of(segment.txnIndex().file().toPath()),
-                file.toPath(),
-                ByteBuffer.wrap(new byte[] {1, 2, 3}));
+            segment.timeIndex().file().toPath(), Optional.of(segment.txnIndex().file().toPath()),
+            file.toPath(),
+            ByteBuffer.wrap(new byte[] {1, 2, 3}));
     }
 
     @Test
@@ -284,8 +284,8 @@ public class S3RemoteStorageManagerTest {
         remoteStorageManager.copyLogSegmentData(createLogSegmentMetadata(segmentId, segment), lsd);
 
         final RemoteLogSegmentMetadata metadata =
-                new RemoteLogSegmentMetadata(segmentId, segment.baseOffset(), -1, -1, -1, 1L,
-                        segment.size(), Collections.singletonMap(1, 100L));
+            new RemoteLogSegmentMetadata(segmentId, segment.baseOffset(), -1, -1, -1, 1L,
+                segment.size(), Collections.singletonMap(1, 100L));
         try (final InputStream remoteInputStream = remoteStorageManager.fetchLogSegment(metadata, 0)) {
             assertStreamContentEqualToFile(segment.log().file(), 0, null, remoteInputStream);
         }
@@ -300,15 +300,15 @@ public class S3RemoteStorageManagerTest {
         remoteStorageManager.copyLogSegmentData(createLogSegmentMetadata(segmentId, segment), lsd);
 
         final RemoteLogSegmentMetadata metadata =
-                new RemoteLogSegmentMetadata(segmentId, segment.baseOffset(), -1, -1, -1, 1L,
-                        segment.log().sizeInBytes(), Collections.singletonMap(1, 100L));
+            new RemoteLogSegmentMetadata(segmentId, segment.baseOffset(), -1, -1, -1, 1L,
+                segment.log().sizeInBytes(), Collections.singletonMap(1, 100L));
 
         final int skipBeginning = 23;
         final int startPosition = skipBeginning;
         final long skipEnd = 42L;
         final long endPosition = segment.log().file().length() - skipEnd;
         try (final InputStream remoteInputStream = remoteStorageManager.fetchLogSegment(metadata, startPosition,
-                (int) endPosition)) {
+            (int) endPosition)) {
             assertStreamContentEqualToFile(segment.log().file(), skipBeginning, skipEnd, remoteInputStream);
         }
     }
@@ -322,12 +322,12 @@ public class S3RemoteStorageManagerTest {
         remoteStorageManager.copyLogSegmentData(createLogSegmentMetadata(segmentId, segment), lsd);
 
         final RemoteLogSegmentMetadata metadata =
-                new RemoteLogSegmentMetadata(segmentId, segment.baseOffset(), -1, -1, -1, 1L,
-                        segment.log().sizeInBytes(),
-                        Collections.singletonMap(1, 100L));
+            new RemoteLogSegmentMetadata(segmentId, segment.baseOffset(), -1, -1, -1, 1L,
+                segment.log().sizeInBytes(),
+                Collections.singletonMap(1, 100L));
 
         try (final InputStream remoteInputStream = remoteStorageManager.fetchIndex(metadata,
-                RemoteStorageManager.IndexType.OFFSET)) {
+            RemoteStorageManager.IndexType.OFFSET)) {
             assertStreamContentEqualToFile(segment.offsetIndex().file(), 0, null, remoteInputStream);
         }
     }
@@ -341,10 +341,10 @@ public class S3RemoteStorageManagerTest {
         remoteStorageManager.copyLogSegmentData(createLogSegmentMetadata(segmentId, segment), lsd);
 
         final RemoteLogSegmentMetadata metadata =
-                new RemoteLogSegmentMetadata(segmentId, segment.baseOffset(), -1, -1, -1, 1L,
-                        segment.log().sizeInBytes(), Collections.singletonMap(1, 100L));
+            new RemoteLogSegmentMetadata(segmentId, segment.baseOffset(), -1, -1, -1, 1L,
+                segment.log().sizeInBytes(), Collections.singletonMap(1, 100L));
         try (final InputStream remoteInputStream = remoteStorageManager.fetchIndex(metadata,
-                RemoteStorageManager.IndexType.TIMESTAMP)) {
+            RemoteStorageManager.IndexType.TIMESTAMP)) {
             assertStreamContentEqualToFile(segment.timeIndex().file(), 0, null, remoteInputStream);
         }
     }
@@ -364,28 +364,28 @@ public class S3RemoteStorageManagerTest {
         remoteStorageManager.copyLogSegmentData(createLogSegmentMetadata(segmentId2, segment2), lsd2);
 
         final RemoteLogSegmentMetadata metadata1 =
-                new RemoteLogSegmentMetadata(segmentId1, 0, -1, -1, -1, 1L, segment1.log().sizeInBytes(),
-                        Collections.singletonMap(1, 100L));
+            new RemoteLogSegmentMetadata(segmentId1, 0, -1, -1, -1, 1L, segment1.log().sizeInBytes(),
+                Collections.singletonMap(1, 100L));
         remoteStorageManager.deleteLogSegmentData(metadata1);
 
         final List<String> keys = listS3Keys();
         final String baseLogFileName2 = segment2.log().file().getName();
         assertThat(keys).containsOnly(
-                s3Key(TP1, uuid2 + "-" + baseLogFileName2) + "_0",
-                s3Key(TP1, uuid2 + "-" + baseLogFileName2) + "_1",
-                s3Key(TP1, uuid2 + "-" + baseLogFileName2) + "_2",
-                s3Key(TP1, uuid2 + "-" + baseLogFileName2) + "_3",
-                s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
-                        + RemoteStorageManager.IndexType.OFFSET),
-                s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
-                        + RemoteStorageManager.IndexType.TIMESTAMP),
-                s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
-                        + RemoteStorageManager.IndexType.PRODUCER_SNAPSHOT),
-                s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
-                        + RemoteStorageManager.IndexType.TRANSACTION),
-                s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
-                        + RemoteStorageManager.IndexType.LEADER_EPOCH),
-                s3Key(TP1, uuid2 + "-" + String.format("%020d", segment2.baseOffset()) + ".metadata.json")
+            s3Key(TP1, uuid2 + "-" + baseLogFileName2) + "_0",
+            s3Key(TP1, uuid2 + "-" + baseLogFileName2) + "_1",
+            s3Key(TP1, uuid2 + "-" + baseLogFileName2) + "_2",
+            s3Key(TP1, uuid2 + "-" + baseLogFileName2) + "_3",
+            s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
+                + RemoteStorageManager.IndexType.OFFSET),
+            s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
+                + RemoteStorageManager.IndexType.TIMESTAMP),
+            s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
+                + RemoteStorageManager.IndexType.PRODUCER_SNAPSHOT),
+            s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
+                + RemoteStorageManager.IndexType.TRANSACTION),
+            s3Key(TP1, uuid2 + "-" + filenamePrefixFromOffset(segment2.baseOffset()) + "."
+                + RemoteStorageManager.IndexType.LEADER_EPOCH),
+            s3Key(TP1, uuid2 + "-" + String.format("%020d", segment2.baseOffset()) + ".metadata.json")
         );
     }
 
@@ -400,12 +400,12 @@ public class S3RemoteStorageManagerTest {
         try (final InputStream fileInputStream = new FileInputStream(expectedFile)) {
             final long skipped = fileInputStream.skip(skipBeginning);
             assertThat(skipped)
-                    .withFailMessage("Failed tp skip the beginning of the excepted file <%s>", expectedFile.getName())
-                    .isEqualTo(skipBeginning);
+                .withFailMessage("Failed tp skip the beginning of the excepted file <%s>", expectedFile.getName())
+                .isEqualTo(skipBeginning);
             final long skip = actual.skip(skipBeginning);
             assertThat(skip)
-                    .withFailMessage("Failed tp skip the beginning of the actual stream")
-                    .isEqualTo(skipBeginning);
+                .withFailMessage("Failed tp skip the beginning of the actual stream")
+                .isEqualTo(skipBeginning);
             length -= skipBeginning;
             assertThat(actual.readAllBytes()).isEqualTo(fileInputStream.readNBytes(length));
         }
@@ -416,7 +416,7 @@ public class S3RemoteStorageManagerTest {
         props.put(S3RemoteStorageManagerConfig.S3_BUCKET_NAME_CONFIG, bucket);
         props.put(S3RemoteStorageManagerConfig.S3_PREFIX, prefix);
         props.put(S3RemoteStorageManagerConfig.S3_CREDENTIALS_PROVIDER_CLASS_CONFIG,
-                AnonymousCredentialsProvider.class.getName());
+            AnonymousCredentialsProvider.class.getName());
         props.put(S3RemoteStorageManagerConfig.PUBLIC_KEY, publicKeyPem.toString());
         props.put(S3RemoteStorageManagerConfig.PRIVATE_KEY, privateKeyPem.toString());
         props.put(S3RemoteStorageManagerConfig.IO_BUFFER_SIZE, "8192");
@@ -428,8 +428,8 @@ public class S3RemoteStorageManagerTest {
     private static RemoteLogSegmentMetadata createLogSegmentMetadata(final RemoteLogSegmentId remoteLogSegmentId,
                                                                      final LogSegment logSegment) {
         return new RemoteLogSegmentMetadata(remoteLogSegmentId, logSegment.baseOffset(),
-                logSegment.readNextOffset() - 1, logSegment.largestTimestamp(),
-                0, logSegment.time().milliseconds(), logSegment.size(), Collections.singletonMap(1, 100L));
+            logSegment.readNextOffset() - 1, logSegment.largestTimestamp(),
+            0, logSegment.time().milliseconds(), logSegment.size(), Collections.singletonMap(1, 100L));
     }
 
     private LogSegment createLogSegment(final long offset) throws IOException {
@@ -457,7 +457,7 @@ public class S3RemoteStorageManagerTest {
         }
         final long lastOffset = offset + numRecords - 1;
         final MemoryRecords memoryRecords = MemoryRecords.withRecords(
-                RecordBatch.CURRENT_MAGIC_VALUE, offset, CompressionType.NONE, TimestampType.CREATE_TIME, records);
+            RecordBatch.CURRENT_MAGIC_VALUE, offset, CompressionType.NONE, TimestampType.CREATE_TIME, records);
         segment.append(lastOffset, timestamp, offset, memoryRecords);
     }
 
@@ -492,9 +492,9 @@ public class S3RemoteStorageManagerTest {
                                     final Time time) throws IOException {
         final FileRecords ms = FileRecords.open(Log.logFile(logDir, offset, ""));
         final LazyIndex<OffsetIndex> idx =
-                LazyIndex.forOffset(Log.offsetIndexFile(logDir, offset, ""), offset, 1000, true);
+            LazyIndex.forOffset(Log.offsetIndexFile(logDir, offset, ""), offset, 1000, true);
         final LazyIndex<TimeIndex> timeIdx =
-                LazyIndex.forTime(Log.timeIndexFile(logDir, offset, ""), offset, 1500, true);
+            LazyIndex.forTime(Log.timeIndexFile(logDir, offset, ""), offset, 1500, true);
         final File file = Log.transactionIndexFile(logDir, offset, "");
         file.createNewFile();
         final TransactionIndex txnIndex = new TransactionIndex(offset, file);

--- a/s3/src/main/java/io/aiven/kafka/tiered/storage/s3/S3RemoteStorageManager.java
+++ b/s3/src/main/java/io/aiven/kafka/tiered/storage/s3/S3RemoteStorageManager.java
@@ -64,7 +64,15 @@ public class S3RemoteStorageManager implements RemoteStorageManager {
     private AmazonS3 initS3Client(final AwsClientBuilder.EndpointConfiguration endpointConfiguration) {
         AmazonS3ClientBuilder s3ClientBuilder = AmazonS3ClientBuilder.standard();
         if (endpointConfiguration == null) {
-            s3ClientBuilder = s3ClientBuilder.withRegion(config.s3Region());
+            if (config.s3EndpointUrl().isEmpty()) {
+                s3ClientBuilder = s3ClientBuilder.withRegion(config.s3Region());
+            } else {
+                final AwsClientBuilder.EndpointConfiguration endpointConfig =
+                    new AwsClientBuilder.EndpointConfiguration(
+                        config.s3EndpointUrl().get(),
+                        config.s3Region().getName());
+                s3ClientBuilder = s3ClientBuilder.withEndpointConfiguration(endpointConfig);
+            }
         } else {
             s3ClientBuilder = s3ClientBuilder.withEndpointConfiguration(endpointConfiguration);
         }
@@ -82,11 +90,11 @@ public class S3RemoteStorageManager implements RemoteStorageManager {
 
     @Override
     public InputStream fetchLogSegment(
-            final RemoteLogSegmentMetadata remoteLogSegmentMetadata,
-            final int startPosition,
-            final int endPosition) throws RemoteStorageException {
+        final RemoteLogSegmentMetadata remoteLogSegmentMetadata,
+        final int startPosition,
+        final int endPosition) throws RemoteStorageException {
         log.info("Fetching log segment from remote storage start position: {}, end position {}.", startPosition,
-                endPosition);
+            endPosition);
         Objects.requireNonNull(remoteLogSegmentMetadata, "remoteLogSegmentMetadata must not be null");
 
         if (startPosition < 0) {
@@ -103,7 +111,7 @@ public class S3RemoteStorageManager implements RemoteStorageManager {
     public InputStream fetchLogSegment(final RemoteLogSegmentMetadata remoteLogSegmentMetadata,
                                        final int startPosition) throws RemoteStorageException {
         log.info("Fetching log segment from remote storage starting from position {}.",
-                remoteLogSegmentMetadata.startOffset());
+            remoteLogSegmentMetadata.startOffset());
         Objects.requireNonNull(remoteLogSegmentMetadata, "remoteLogSegmentMetadata must not be null");
 
         if (startPosition < 0) {
@@ -116,15 +124,15 @@ public class S3RemoteStorageManager implements RemoteStorageManager {
 
     @Override
     public InputStream fetchIndex(final RemoteLogSegmentMetadata remoteLogSegmentMetadata, final IndexType indexType)
-            throws RemoteStorageException {
+        throws RemoteStorageException {
         log.info("Fetching {} index from remote storage for segment with offset {}.", indexType,
-                remoteLogSegmentMetadata.startOffset());
+            remoteLogSegmentMetadata.startOffset());
         return s3ClientWrapper.fetchIndexFile(remoteLogSegmentMetadata, indexType);
     }
 
     @Override
     public void deleteLogSegmentData(final RemoteLogSegmentMetadata remoteLogSegmentMetadata)
-            throws RemoteStorageException {
+        throws RemoteStorageException {
         log.info("Deleting log segment from remote storage for offset {}", remoteLogSegmentMetadata.startOffset());
         Objects.requireNonNull(remoteLogSegmentMetadata, "remoteLogSegmentMetadata must not be null");
 
@@ -132,8 +140,8 @@ public class S3RemoteStorageManager implements RemoteStorageManager {
             s3ClientWrapper.deleteSegmentData(remoteLogSegmentMetadata);
         } catch (final Exception e) {
             throw new RemoteStorageException(
-                    String.format("Error deleting files for %s ", remoteLogSegmentMetadata.remoteLogSegmentId().id()),
-                    e);
+                String.format("Error deleting files for %s ", remoteLogSegmentMetadata.remoteLogSegmentId().id()),
+                e);
         }
     }
 

--- a/s3/src/main/java/io/aiven/kafka/tiered/storage/s3/S3RemoteStorageManagerConfig.java
+++ b/s3/src/main/java/io/aiven/kafka/tiered/storage/s3/S3RemoteStorageManagerConfig.java
@@ -19,8 +19,8 @@ package io.aiven.kafka.tiered.storage.s3;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
 import java.util.Optional;
+
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
@@ -42,7 +42,8 @@ public class S3RemoteStorageManagerConfig extends AbstractConfig {
     private static final String S3_BUCKET_NAME_DOC = "The S3 Bucket.";
 
     public static final String S3_ENDPOINT_URL_CONFIG = "s3.endpoint.url";
-    private static final String S3_ENDPOINT_URL_DOC = "Custom S3 endpoint URL. When null (default), AWS S3 default endpoint is used.";
+    private static final String S3_ENDPOINT_URL_DOC =
+        "Custom S3 endpoint URL. When null (default), AWS S3 default endpoint is used.";
 
     public static final String S3_PREFIX = "s3.prefix";
 
@@ -55,8 +56,8 @@ public class S3RemoteStorageManagerConfig extends AbstractConfig {
     public static final String S3_CREDENTIALS_PROVIDER_CLASS_CONFIG = "s3.credentials.provider.class";
     private static final Class<? extends AWSCredentialsProvider> S3_CREDENTIALS_PROVIDER_CLASS_DEFAULT = null;
     private static final String S3_CREDENTIALS_PROVIDER_CLASS_DOC = "The credentials provider to use for "
-            + "authentication to AWS. If not set, AWS SDK uses the default "
-            + "com.amazonaws.auth.DefaultAWSCredentialsProviderChain";
+        + "authentication to AWS. If not set, AWS SDK uses the default "
+        + "com.amazonaws.auth.DefaultAWSCredentialsProviderChain";
 
     public static final String PUBLIC_KEY = "s3.public_key_pem";
     private static final String PUBLIC_KEY_DOC = "Public key for storage encryption";
@@ -83,7 +84,7 @@ public class S3RemoteStorageManagerConfig extends AbstractConfig {
     public static final String ENCRYPTION_METADATA_CACHE_RETENTION_MS = "s3.encryption.metadata.cache.retention.ms";
     public static final long ENCRYPTION_METADATA_CACHE_RETENTION_MS_DEFAULT = 1_800_000;
     private static final String ENCRYPTION_METADATA_CACHE_RETENTION_MS_DOC =
-            "Retention time for encryption metadata cache";
+        "Retention time for encryption metadata cache";
 
     public static final String AWS_ACCESS_KEY_ID = "s3.client.aws_access_key_id";
     private static final String AWS_ACCESS_KEY_ID_DOC = "AWS Access Key ID";
@@ -176,21 +177,21 @@ public class S3RemoteStorageManagerConfig extends AbstractConfig {
         );
 
         CONFIG.define(
-                ENCRYPTION_METADATA_CACHE_SIZE,
-                ConfigDef.Type.LONG,
-                ENCRYPTION_METADATA_CACHE_SIZE_DEFAULT,
-                ConfigDef.Range.between(0, Long.MAX_VALUE),
-                ConfigDef.Importance.LOW,
-                ENCRYPTION_METADATA_CACHE_SIZE_DOC
+            ENCRYPTION_METADATA_CACHE_SIZE,
+            ConfigDef.Type.LONG,
+            ENCRYPTION_METADATA_CACHE_SIZE_DEFAULT,
+            ConfigDef.Range.between(0, Long.MAX_VALUE),
+            ConfigDef.Importance.LOW,
+            ENCRYPTION_METADATA_CACHE_SIZE_DOC
         );
 
         CONFIG.define(
-                ENCRYPTION_METADATA_CACHE_RETENTION_MS,
-                ConfigDef.Type.LONG,
-                ENCRYPTION_METADATA_CACHE_RETENTION_MS_DEFAULT,
-                ConfigDef.Range.between(0, Long.MAX_VALUE),
-                ConfigDef.Importance.LOW,
-                ENCRYPTION_METADATA_CACHE_RETENTION_MS_DOC
+            ENCRYPTION_METADATA_CACHE_RETENTION_MS,
+            ConfigDef.Type.LONG,
+            ENCRYPTION_METADATA_CACHE_RETENTION_MS_DEFAULT,
+            ConfigDef.Range.between(0, Long.MAX_VALUE),
+            ConfigDef.Importance.LOW,
+            ENCRYPTION_METADATA_CACHE_RETENTION_MS_DOC
         );
 
         int awsGroupCounter = 0;
@@ -227,29 +228,29 @@ public class S3RemoteStorageManagerConfig extends AbstractConfig {
         );
 
         CONFIG.define(
-                AWS_ACCESS_KEY_ID,
-                ConfigDef.Type.PASSWORD,
-                null,
-                new NonEmptyPassword(),
-                ConfigDef.Importance.MEDIUM,
-                AWS_ACCESS_KEY_ID_DOC,
-                GROUP_AWS,
-                awsGroupCounter++,
-                ConfigDef.Width.NONE,
-                AWS_ACCESS_KEY_ID
+            AWS_ACCESS_KEY_ID,
+            ConfigDef.Type.PASSWORD,
+            null,
+            new NonEmptyPassword(),
+            ConfigDef.Importance.MEDIUM,
+            AWS_ACCESS_KEY_ID_DOC,
+            GROUP_AWS,
+            awsGroupCounter++,
+            ConfigDef.Width.NONE,
+            AWS_ACCESS_KEY_ID
         );
 
         CONFIG.define(
-                AWS_SECRET_ACCESS_KEY,
-                ConfigDef.Type.PASSWORD,
-                null,
-                new NonEmptyPassword(),
-                ConfigDef.Importance.MEDIUM,
-                AWS_SECRET_ACCESS_KEY_DOC,
-                GROUP_AWS,
-                awsGroupCounter++,
-                ConfigDef.Width.NONE,
-                AWS_SECRET_ACCESS_KEY
+            AWS_SECRET_ACCESS_KEY,
+            ConfigDef.Type.PASSWORD,
+            null,
+            new NonEmptyPassword(),
+            ConfigDef.Importance.MEDIUM,
+            AWS_SECRET_ACCESS_KEY_DOC,
+            GROUP_AWS,
+            awsGroupCounter++,
+            ConfigDef.Width.NONE,
+            AWS_SECRET_ACCESS_KEY
         );
     }
 
@@ -304,9 +305,9 @@ public class S3RemoteStorageManagerConfig extends AbstractConfig {
 
     public AWSCredentialsProvider awsCredentialsProvider() {
         try {
-            @SuppressWarnings("unchecked")
-            final Class<? extends AWSCredentialsProvider> providerClass = (Class<? extends AWSCredentialsProvider>)
-                getClass(S3_CREDENTIALS_PROVIDER_CLASS_CONFIG);
+            @SuppressWarnings("unchecked") final Class<? extends AWSCredentialsProvider> providerClass =
+                (Class<? extends AWSCredentialsProvider>)
+                    getClass(S3_CREDENTIALS_PROVIDER_CLASS_CONFIG);
             if (providerClass == null) {
                 return null;
             }
@@ -321,7 +322,7 @@ public class S3RemoteStorageManagerConfig extends AbstractConfig {
 
     public AWSCredentials awsCredentials() {
         return new BasicAWSCredentials(getPassword(AWS_ACCESS_KEY_ID).value(),
-                getPassword(AWS_SECRET_ACCESS_KEY).value());
+            getPassword(AWS_SECRET_ACCESS_KEY).value());
     }
 
     private static class RegionValidator implements ConfigDef.Validator {

--- a/s3/src/main/java/io/aiven/kafka/tiered/storage/s3/S3RemoteStorageManagerConfig.java
+++ b/s3/src/main/java/io/aiven/kafka/tiered/storage/s3/S3RemoteStorageManagerConfig.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import java.util.Optional;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
@@ -39,6 +40,9 @@ public class S3RemoteStorageManagerConfig extends AbstractConfig {
 
     public static final String S3_BUCKET_NAME_CONFIG = "s3.bucket.name";
     private static final String S3_BUCKET_NAME_DOC = "The S3 Bucket.";
+
+    public static final String S3_ENDPOINT_URL_CONFIG = "s3.endpoint.url";
+    private static final String S3_ENDPOINT_URL_DOC = "Custom S3 endpoint URL. When null (default), AWS S3 default endpoint is used.";
 
     public static final String S3_PREFIX = "s3.prefix";
 
@@ -100,6 +104,13 @@ public class S3RemoteStorageManagerConfig extends AbstractConfig {
             new ConfigDef.NonEmptyString(),
             ConfigDef.Importance.HIGH,
             S3_BUCKET_NAME_DOC
+        );
+        CONFIG.define(
+            S3_ENDPOINT_URL_CONFIG,
+            ConfigDef.Type.STRING,
+            null,
+            ConfigDef.Importance.LOW,
+            S3_ENDPOINT_URL_DOC
         );
 
         CONFIG.define(
@@ -257,6 +268,10 @@ public class S3RemoteStorageManagerConfig extends AbstractConfig {
     public Regions s3Region() {
         final String regionStr = getString(S3_REGION_CONFIG);
         return Regions.fromName(regionStr);
+    }
+
+    public Optional<String> s3EndpointUrl() {
+        return Optional.ofNullable(getString(S3_ENDPOINT_URL_CONFIG));
     }
 
     public String publicKey() {


### PR DESCRIPTION
While enabling a testing environment (see #144), there is a need to point to localstack or minio (or any s3 compatible endpoint), but plugin currently doesn't expose this configuration.

Depends on #144 