### PR TITLE
feat: add local tiered storage impl to docker options

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,18 @@
+all:
+
+# Defaults
+t=t1
+segment=10000000 # 10M
+retention=500000000 # 500M
+local_retention=50000000 # 50M
+
+ts-topic:
+	${KAFKA_HOME}/bin/kafka-topics.sh \
+		--bootstrap-server localhost:9092 \
+		--create \
+		--config remote.storage.enable=true \
+		--config segment.bytes=$(segment) \
+		--config retention.bytes=$(retention) \
+		--config local.retention.bytes=$(local_retention) \
+		--partitions 6 \
+		--topic $(t)

--- a/docker/kafka/Dockerfile
+++ b/docker/kafka/Dockerfile
@@ -7,20 +7,28 @@ ENV JAVA_HOME /usr/lib/jvm/java-${JAVA_VERSION}-openjdk
 ARG AK_REPO=https://github.com/apache/kafka
 ARG AK_BRANCH=3.4
 
+ENV SCALA_VERSION 2.13
+ARG KAFKA_VERSION=3.4.1-SNAPSHOT
+
 RUN git clone ${AK_REPO}
 
 WORKDIR /kafka
 RUN git checkout ${AK_BRANCH}
 
-RUN ./gradlew releaseTarGz
+RUN ./gradlew clean testJar releaseTarGz
+WORKDIR /kafka/core/build/distributions
+RUN tar xf kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz;
 
 FROM eclipse-temurin:17-jre AS kafka
 
 ENV SCALA_VERSION 2.13
 ARG KAFKA_VERSION=3.4.1-SNAPSHOT
 
-COPY --from=base /kafka/core/build/distributions/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz ./kafka.tgz
-RUN tar xf kafka.tgz; mv /kafka_${SCALA_VERSION}-${KAFKA_VERSION} /kafka
+COPY --from=base /kafka/core/build/distributions/kafka_${SCALA_VERSION}-${KAFKA_VERSION} /kafka
+# Adding test jars with local implementations
+COPY --from=base /kafka/clients/build/libs/kafka-clients-${KAFKA_VERSION}-test.jar /kafka/libs/
+COPY --from=base /kafka/storage/build/libs/kafka-storage-${KAFKA_VERSION}-test.jar /kafka/libs/
+COPY --from=base /kafka/storage/api/build/libs/kafka-storage-api-${KAFKA_VERSION}-test.jar /kafka/libs/
 
 ENV KAFKA_HOME /kafka
 WORKDIR ${KAFKA_HOME}

--- a/docker/s3/Makefile
+++ b/docker/s3/Makefile
@@ -1,23 +1,6 @@
-all: build up
-
-build:
-	docker compose build
-
-up:
-	docker compose up -d
+all:
 
 # Generate keys for S3 plugin
 rsa-keys:
 	openssl genrsa -out private.pem 512
 	openssl rsa -in private.pem -outform PEM -out public.pem -pubout
-
-topic:
-	${KAFKA_HOME}/bin/kafka-topics.sh \
-		--bootstrap-server localhost:9092 \
-		--create \
-		--config segment.bytes=1000000 \
-		--config retention.bytes=100000000 \
-		--config remote.storage.enable=true \
-		--config local.retention.bytes=2000000 \
-		--partitions 6 \
-		--topic t1

--- a/docker/test/.gitignore
+++ b/docker/test/.gitignore
@@ -1,0 +1,2 @@
+# Backend volumes
+data/

--- a/docker/test/compose.yml
+++ b/docker/test/compose.yml
@@ -1,0 +1,59 @@
+version: '3.8'
+services:
+  zookeeper:
+    image: kafka
+    build:
+      context: ../kafka/.
+      args:
+        - AK_REPO=https://github.com/aiven/kafka
+        - AK_BRANCH=3.3-2022-10-06-tiered-storage
+        - KAFKA_VERSION=3.3.2-SNAPSHOT
+    command:
+      - zookeeper-server-start.sh
+      - config/zookeeper.properties
+
+  kafka:
+    image: kafka
+    build:
+      context: ../kafka/.
+      args:
+        - AK_REPO=https://github.com/aiven/kafka
+        - AK_BRANCH=3.3-2022-10-06-tiered-storage
+        - KAFKA_VERSION=3.3.2-SNAPSHOT
+    ports:
+      - "9092:9092"
+    volumes:
+      # mount local dir for second tier
+      - ./data:/kafka/kafka-tiered-storage/data
+    environment: 
+      - INCLUDE_TEST_JARS=true
+    command:
+      - kafka-server-start.sh
+      - config/server.properties
+      - --override
+      - zookeeper.connect=zookeeper:2181
+      - --override
+      - listeners=BROKER://kafka:29092,EXTERNAL://kafka:9092
+      - --override
+      - advertised.listeners=BROKER://kafka:29092,EXTERNAL://localhost:9092
+      - --override
+      - listener.security.protocol.map=BROKER:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - --override
+      - inter.broker.listener.name=BROKER
+      # Enable Tiered storage
+      - --override
+      - remote.log.storage.system.enable=true
+      - --override
+      - remote.log.storage.manager.class.name=org.apache.kafka.server.log.remote.storage.LocalTieredStorage
+      - --override
+      - remote.log.storage.manager.class.path=
+      # Tiered storage S3 plugin
+      - --override
+      - rsm.config.dir=/data
+      # Tiered Storage: RLMM config
+      - --override
+      - remote.log.metadata.manager.class.name=org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManager
+      - --override
+      - rlmm.config.remote.log.metadata.common.client.bootstrap.servers=kafka:29092
+      - --override
+      - rlmm.config.remote.log.metadata.topic.replication.factor=1


### PR DESCRIPTION
Adds a new docker compose configuration to use local tiered storage implemented in https://github.com/aiven/kafka/blob/93ae220db12e8294b2cfe8871a2583b53de8b775/storage/src/test/java/org/apache/kafka/server/log/remote/storage/LocalTieredStorage.java, and follows https://github.com/aiven/kafka/blob/3.3-2022-10-06-tiered-storage/storage/src/test/README.md to configure plugin.

This should help us to compare plugin implementations.
