### PR TITLE
[DRAFT] Experimental minimal S3 plugin

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -3,6 +3,3 @@
 
 # Demo keys
 *.pem
-
-# Backend volumes
-minio/

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,15 +1,10 @@
-all: build up
-
-build:
-	docker compose build
-
-up:
-	docker compose up -d
+all:
 
 # Generate keys for S3 plugin
 rsa-keys:
 	openssl genrsa -out private.pem 512
 	openssl rsa -in private.pem -outform PEM -out public.pem -pubout
+<<<<<<<< HEAD:docker/Makefile
 
 # Topic Defaults
 t=t1
@@ -27,3 +22,5 @@ kafka-topic:
 		--config local.retention.bytes=$(local_retention) \
 		--partitions $(p) \
 		--topic $(t)
+========
+>>>>>>>> ff77535 (feat: add local tiered storage impl to docker options):docker/s3/Makefile

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -18,11 +18,10 @@ segment=100000000 # 100M
 retention=1000000000 # 1G
 local_retention=300000000 # 300M
 
-ts-topic:
+kafka-topic:
 	${KAFKA_HOME}/bin/kafka-topics.sh \
 		--bootstrap-server localhost:9092 \
 		--create \
-		--config remote.storage.enable=true \
 		--config segment.bytes=$(segment) \
 		--config retention.bytes=$(retention) \
 		--config local.retention.bytes=$(local_retention) \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -11,13 +11,20 @@ rsa-keys:
 	openssl genrsa -out private.pem 512
 	openssl rsa -in private.pem -outform PEM -out public.pem -pubout
 
-topic:
+# Topic Defaults
+t=t1
+p=6
+segment=100000000 # 100M
+retention=1000000000 # 1G
+local_retention=300000000 # 300M
+
+ts-topic:
 	${KAFKA_HOME}/bin/kafka-topics.sh \
 		--bootstrap-server localhost:9092 \
 		--create \
-		--config segment.bytes=1000000 \
-		--config retention.bytes=100000000 \
 		--config remote.storage.enable=true \
-		--config local.retention.bytes=2000000 \
-		--partitions 6 \
-		--topic t1
+		--config segment.bytes=$(segment) \
+		--config retention.bytes=$(retention) \
+		--config local.retention.bytes=$(local_retention) \
+		--partitions $(p) \
+		--topic $(t)

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,17 +11,50 @@ Docker compose environment to try out tiered storage plugins.
 
 ## How to use
 
-### S3
-
-> on [./s3](./s3) directory
+### Pre-requisites
 
 Build plugin before starting Docker compose:
+
+#### Build plugin libraries
 
 On root directory:
 
 ```shell
-./gradlew clean s3:installDist
+./gradlew clean installDist
 ```
+
+#### Using Encryption mechanisms
+
+Generate RSA key pair:
+
+```shell
+make rsa-keys
+```
+
+and set paths on `compose.yml` file:
+
+```yaml
+  kafka:
+    # ...
+    volumes:
+      # ...
+      - ./private.pem:/kafka/plugins/private.pem
+      - ./public.pem:/kafka/plugins/public.pem
+    command:
+      - kafka-server-start.sh
+      - config/server.properties
+      # ...
+      - --override
+      - rsm.config.s3.public_key_pem=/kafka/plugins/public.pem
+      - --override
+      - rsm.config.s3.private_key_pem=/kafka/plugins/private.pem
+      # ...
+```
+
+### S3
+
+> for AWS S3 try [./s3](./s3) directory and
+> for Minio S3 try [./s3-minio](./s3-minio) directory
 
 `compose.yml` is mounting the distribution directory:
 
@@ -64,34 +97,6 @@ and use variables on `compose.yml`:
       - rsm.config.s3.client.aws_access_key_id=${AWS_ACCESS_KEY_ID}
       - --override
       - rsm.config.s3.client.aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
-```
-
-#### Using Encryption mechanisms
-
-Generate RSA key pair:
-
-```shell
-make rsa-keys
-```
-
-and set paths on `compose.yml` file:
-
-```yaml
-  kafka:
-    # ...
-    volumes:
-      # ...
-      - ./private.pem:/kafka/plugins/private.pem
-      - ./public.pem:/kafka/plugins/public.pem
-    command:
-      - kafka-server-start.sh
-      - config/server.properties
-      # ...
-      - --override
-      - rsm.config.s3.public_key_pem=/kafka/plugins/public.pem
-      - --override
-      - rsm.config.s3.private_key_pem=/kafka/plugins/private.pem
-      # ...
 ```
 
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -105,7 +105,7 @@ and use variables on `compose.yml`:
 Creating topics with Tiered storage:
 
 ```shell
-make topic
+make kafka-topic
 ```
 
 creates a topic t1 with 6 partitions, 10MB segments, retention bytes 100MB, and 20MB local retention.

--- a/docker/kafka/Dockerfile
+++ b/docker/kafka/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:37 AS base
 
-ENV JAVA_VERSION 17
+ENV JAVA_VERSION 11
 RUN dnf install -y java-${JAVA_VERSION}-openjdk-devel git
 
 ENV JAVA_HOME /usr/lib/jvm/java-${JAVA_VERSION}-openjdk
@@ -12,11 +12,12 @@ RUN git clone ${AK_REPO}
 WORKDIR /kafka
 RUN git checkout ${AK_BRANCH}
 
-RUN ./gradlew releaseTarGz
+ENV SCALA_VERSION 2.12
+RUN ./gradlew -PscalaVersion=${SCALA_VERSION} releaseTarGz
 
 FROM eclipse-temurin:17-jre AS kafka
 
-ENV SCALA_VERSION 2.13
+ENV SCALA_VERSION 2.12
 ARG KAFKA_VERSION=3.4.1-SNAPSHOT
 
 COPY --from=base /kafka/core/build/distributions/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz ./kafka.tgz

--- a/docker/s3-minio/compose.yml
+++ b/docker/s3-minio/compose.yml
@@ -1,13 +1,13 @@
 version: '3.8'
 services:
   zookeeper:
-    image: kafka-ts-s3-aws
+    image: kafka-ts-s3-minio
     command:
       - zookeeper-server-start.sh
       - config/zookeeper.properties
 
   kafka:
-    image: kafka-ts-s3-aws
+    image: kafka-ts-s3-minio
     build:
       context: ../kafka/.
       args:
@@ -19,9 +19,6 @@ services:
     volumes:
       # mount plugin
       - ./../../s3/build/install/s3:/kafka/plugins/tiered-storage-s3
-      # encryption keys
-      - ./private.pem:/kafka/plugins/private.pem
-      - ./public.pem:/kafka/plugins/public.pem
     command:
       - kafka-server-start.sh
       - config/server.properties
@@ -40,10 +37,6 @@ services:
       - remote.log.storage.system.enable=true
       # Tiered Storage: RLMM config
       - --override
-      - remote.log.storage.manager.class.name=io.aiven.kafka.tiered.storage.s3.S3RemoteStorageManager
-      - --override
-      - remote.log.storage.manager.class.path=/kafka/plugins/tiered-storage-s3/*
-      - --override
       - remote.log.metadata.manager.class.name=org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManager
       - --override
       - rlmm.config.remote.log.metadata.common.client.bootstrap.servers=kafka:29092
@@ -55,6 +48,8 @@ services:
       - --override
       - rsm.config.s3.region=us-east-1
       - --override
+      - rsm.config.s3.endpoint.url=http://minio:9000
+      - --override
       - rsm.config.s3.credentials.provider.class=com.amazonaws.auth.AWSStaticCredentialsProvider
       - --override
       - rsm.config.s3.client.aws_access_key_id=${AWS_ACCESS_KEY_ID}
@@ -64,3 +59,14 @@ services:
       - rsm.config.s3.public_key_pem=/kafka/plugins/public.pem
       - --override
       - rsm.config.s3.private_key_pem=/kafka/plugins/private.pem
+
+  minio:
+    image: quay.io/minio/minio
+    environment:
+      - MINIO_ROOT_USER=admin
+      - MINIO_ROOT_PASSWORD=password
+      - MINIO_DOMAIN=minio
+    ports:
+      - "9000:9000"
+      - "9090:9090"
+    command: server /data --console-address ":9090"

--- a/docker/s3-minio/compose.yml
+++ b/docker/s3-minio/compose.yml
@@ -19,6 +19,9 @@ services:
     volumes:
       # mount plugin
       - ./../../s3/build/install/s3:/kafka/plugins/tiered-storage-s3
+      # encryption keys
+      - ./../private.pem:/kafka/plugins/private.pem
+      - ./../public.pem:/kafka/plugins/public.pem
     command:
       - kafka-server-start.sh
       - config/server.properties
@@ -44,6 +47,10 @@ services:
       - rlmm.config.remote.log.metadata.topic.replication.factor=1
       # Tiered storage S3 plugin
       - --override
+      - remote.log.storage.manager.class.name=io.aiven.kafka.tiered.storage.s3.S3RemoteStorageManager
+      - --override
+      - remote.log.storage.manager.class.path=/kafka/plugins/tiered-storage-s3/*
+      - --override
       - rsm.config.s3.bucket.name=kafka-ts-us-east-1
       - --override
       - rsm.config.s3.region=us-east-1
@@ -52,9 +59,9 @@ services:
       - --override
       - rsm.config.s3.credentials.provider.class=com.amazonaws.auth.AWSStaticCredentialsProvider
       - --override
-      - rsm.config.s3.client.aws_access_key_id=${AWS_ACCESS_KEY_ID}
+      - rsm.config.s3.client.aws_access_key_id=admin
       - --override
-      - rsm.config.s3.client.aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+      - rsm.config.s3.client.aws_secret_access_key=password
       - --override
       - rsm.config.s3.public_key_pem=/kafka/plugins/public.pem
       - --override

--- a/docker/s3-minio/compose.yml
+++ b/docker/s3-minio/compose.yml
@@ -12,8 +12,8 @@ services:
       context: ../kafka/.
       args:
         - AK_REPO=https://github.com/aiven/kafka
-        - AK_BRANCH=3.3-2022-10-06-tiered-storage
-        - KAFKA_VERSION=3.3.2-SNAPSHOT
+        - AK_BRANCH=3.0-2022-03-31-tiered-storage
+        - KAFKA_VERSION=3.0.1-SNAPSHOT
     ports:
       - "9092:9092"
     volumes:

--- a/docker/s3-minio/compose.yml
+++ b/docker/s3-minio/compose.yml
@@ -18,10 +18,7 @@ services:
       - "9092:9092"
     volumes:
       # mount plugin
-      - ./../../s3/build/install/s3:/kafka/plugins/tiered-storage-s3
-      # encryption keys
-      - ./../private.pem:/kafka/plugins/private.pem
-      - ./../public.pem:/kafka/plugins/public.pem
+      - ./../../s3-minimal/build/install/s3-minimal:/kafka/plugins/tiered-storage-s3
     command:
       - kafka-server-start.sh
       - config/server.properties
@@ -47,25 +44,19 @@ services:
       - rlmm.config.remote.log.metadata.topic.replication.factor=1
       # Tiered storage S3 plugin
       - --override
-      - remote.log.storage.manager.class.name=io.aiven.kafka.tiered.storage.s3.S3RemoteStorageManager
+      - remote.log.storage.manager.class.name=io.aiven.kafka.tieredstorage.s3.S3TieredStorage
       - --override
       - remote.log.storage.manager.class.path=/kafka/plugins/tiered-storage-s3/*
       - --override
-      - rsm.config.s3.bucket.name=kafka-ts-us-east-1
-      - --override
-      - rsm.config.s3.region=us-east-1
+      - rsm.config.s3.bucket.name=kafka-ts-v1
       - --override
       - rsm.config.s3.endpoint.url=http://minio:9000
       - --override
-      - rsm.config.s3.credentials.provider.class=com.amazonaws.auth.AWSStaticCredentialsProvider
+      - rsm.config.s3.aws.credentials.provider.class=com.amazonaws.auth.AWSStaticCredentialsProvider
       - --override
-      - rsm.config.s3.client.aws_access_key_id=admin
+      - rsm.config.s3.aws.access.key.id=admin
       - --override
-      - rsm.config.s3.client.aws_secret_access_key=password
-      - --override
-      - rsm.config.s3.public_key_pem=/kafka/plugins/public.pem
-      - --override
-      - rsm.config.s3.private_key_pem=/kafka/plugins/private.pem
+      - rsm.config.s3.aws.secret.access.key=password
 
   minio:
     image: quay.io/minio/minio

--- a/docker/s3/compose.yml
+++ b/docker/s3/compose.yml
@@ -12,8 +12,8 @@ services:
       context: ../kafka/.
       args:
         - AK_REPO=https://github.com/aiven/kafka
-        - AK_BRANCH=3.3-2022-10-06-tiered-storage
-        - KAFKA_VERSION=3.3.2-SNAPSHOT
+        - AK_BRANCH=3.0-2022-03-31-tiered-storage
+        - KAFKA_VERSION=3.0.1-SNAPSHOT
     ports:
       - "9092:9092"
     volumes:

--- a/docker/s3/compose.yml
+++ b/docker/s3/compose.yml
@@ -18,10 +18,7 @@ services:
       - "9092:9092"
     volumes:
       # mount plugin
-      - ./../../s3/build/install/s3:/kafka/plugins/tiered-storage-s3
-      # encryption keys
-      - ./../private.pem:/kafka/plugins/private.pem
-      - ./../public.pem:/kafka/plugins/public.pem
+      - ./../../s3-minimal/build/install/s3-minimal:/kafka/plugins/tiered-storage-s3
     command:
       - kafka-server-start.sh
       - config/server.properties
@@ -47,20 +44,18 @@ services:
       - rlmm.config.remote.log.metadata.topic.replication.factor=1
       # Tiered storage S3 plugin
       - --override
-      - remote.log.storage.manager.class.name=io.aiven.kafka.tiered.storage.s3.S3RemoteStorageManager
+      - remote.log.storage.manager.class.name=io.aiven.kafka.tieredstorage.s3.S3TieredStorage
       - --override
       - remote.log.storage.manager.class.path=/kafka/plugins/tiered-storage-s3/*
       - --override
-      - rsm.config.s3.bucket.name=kafka-ts-us-east-1
+      - rsm.config.s3.bucket.name=aiven-jeqo-test1
       - --override
-      - rsm.config.s3.region=us-east-1
+      - rsm.config.s3.object.prefix=kafka-ts-v1/cluster1
       - --override
-      - rsm.config.s3.credentials.provider.class=com.amazonaws.auth.AWSStaticCredentialsProvider
+      - rsm.config.s3.aws.region=eu-north-1
       - --override
-      - rsm.config.s3.client.aws_access_key_id=${AWS_ACCESS_KEY_ID}
+      - rsm.config.s3.aws.credentials.provider.class=com.amazonaws.auth.AWSStaticCredentialsProvider
       - --override
-      - rsm.config.s3.client.aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+      - rsm.config.s3.aws.access.key.id=${AWS_ACCESS_KEY_ID}
       - --override
-      - rsm.config.s3.public_key_pem=/kafka/plugins/public.pem
-      - --override
-      - rsm.config.s3.private_key_pem=/kafka/plugins/private.pem
+      - rsm.config.s3.aws.secret.access.key=${AWS_SECRET_ACCESS_KEY}

--- a/docker/s3/compose.yml
+++ b/docker/s3/compose.yml
@@ -20,8 +20,8 @@ services:
       # mount plugin
       - ./../../s3/build/install/s3:/kafka/plugins/tiered-storage-s3
       # encryption keys
-      - ./private.pem:/kafka/plugins/private.pem
-      - ./public.pem:/kafka/plugins/public.pem
+      - ./../private.pem:/kafka/plugins/private.pem
+      - ./../public.pem:/kafka/plugins/public.pem
     command:
       - kafka-server-start.sh
       - config/server.properties
@@ -40,16 +40,16 @@ services:
       - remote.log.storage.system.enable=true
       # Tiered Storage: RLMM config
       - --override
-      - remote.log.storage.manager.class.name=io.aiven.kafka.tiered.storage.s3.S3RemoteStorageManager
-      - --override
-      - remote.log.storage.manager.class.path=/kafka/plugins/tiered-storage-s3/*
-      - --override
       - remote.log.metadata.manager.class.name=org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManager
       - --override
       - rlmm.config.remote.log.metadata.common.client.bootstrap.servers=kafka:29092
       - --override
       - rlmm.config.remote.log.metadata.topic.replication.factor=1
       # Tiered storage S3 plugin
+      - --override
+      - remote.log.storage.manager.class.name=io.aiven.kafka.tiered.storage.s3.S3RemoteStorageManager
+      - --override
+      - remote.log.storage.manager.class.path=/kafka/plugins/tiered-storage-s3/*
       - --override
       - rsm.config.s3.bucket.name=kafka-ts-us-east-1
       - --override

--- a/s3-minimal/build.gradle
+++ b/s3-minimal/build.gradle
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+configurations {
+    integrationTestImplementation.extendsFrom testImplementation
+    integrationTestRuntime.extendsFrom testRuntimeClasspath
+}
+
+dependencies {
+    implementation project(':commons')
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.440'
+    implementation 'commons-io:commons-io:2.11.0'
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.5'
+    // Temporary. Will be later provided as transitive from kafka-storage-api
+    runtimeOnly 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
+    // Temporary. Will be later provided as transitive from kafka-clients.
+    runtimeOnly "com.github.luben:zstd-jni:1.5.4-2"
+    testImplementation 'org.mockito:mockito-core:5.2.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.2.0'
+    testRuntimeOnly "org.slf4j:slf4j-log4j12:2.0.7"
+    integrationTestImplementation "org.testcontainers:localstack:$testcontainersVersion"
+}
+
+sourceSets {
+    integrationTest {
+        java.srcDirs = ['src/integration-test/java']
+        compileClasspath += sourceSets.main.output + configurations.testRuntimeClasspath
+        runtimeClasspath += output + compileClasspath
+    }
+}
+
+idea {
+    module {
+        testSourceDirs += project.sourceSets.integrationTest.java.srcDirs
+        testSourceDirs += project.sourceSets.integrationTest.resources.srcDirs
+    }
+}
+
+tasks.register('integrationTest', Test) {
+    description = 'Runs the integration tests.'
+    group = 'verification'
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
+
+    dependsOn test, distTar
+
+    useJUnitPlatform()
+
+    // Run always.
+    outputs.upToDateWhen { false }
+    // Pass the distribution file path to the tests.
+    systemProperty("integration-test.distribution.file.path", distTar.archiveFile.get().asFile.path)
+}

--- a/s3-minimal/src/integration-test/java/io/aiven/kafka/tieredstorage/s3/S3Playground.java
+++ b/s3-minimal/src/integration-test/java/io/aiven/kafka/tieredstorage/s3/S3Playground.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.s3;
+
+import java.util.Map;
+
+import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.PutObjectResult;
+
+import static io.aiven.kafka.tieredstorage.s3.S3TieredStorageConfig.AWS_REGION_CONFIG;
+import static io.aiven.kafka.tieredstorage.s3.S3TieredStorageConfig.S3_BUCKET_NAME_CONFIG;
+import static io.aiven.kafka.tieredstorage.s3.S3TieredStorageConfig.S3_OBJECT_PREFIX_CONFIG;
+
+public class S3Playground {
+    public static void main(final String[] args) {
+        final Map<String, ?> props = Map.of(
+            S3_BUCKET_NAME_CONFIG, "aiven-jeqo-test1",
+            S3_OBJECT_PREFIX_CONFIG, "kafka-ts/cluster1",
+            AWS_REGION_CONFIG, "eu-north-1"
+        );
+        final S3TieredStorageConfig config = new S3TieredStorageConfig(props);
+        System.out.println(config);
+        final EnvironmentVariableCredentialsProvider provider = new EnvironmentVariableCredentialsProvider();
+        final AmazonS3 client = config.s3Client(provider);
+        final PutObjectResult result = client.putObject(config.bucketName(), "test", "test");
+        System.out.println(result.getMetadata());
+    }
+}

--- a/s3-minimal/src/main/java/io/aiven/kafka/tieredstorage/s3/S3TieredStorage.java
+++ b/s3-minimal/src/main/java/io/aiven/kafka/tieredstorage/s3/S3TieredStorage.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2021 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.s3;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.utils.ByteBufferInputStream;
+import org.apache.kafka.server.log.remote.storage.LogSegmentData;
+import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
+import org.apache.kafka.server.log.remote.storage.RemoteStorageException;
+import org.apache.kafka.server.log.remote.storage.RemoteStorageManager;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class S3TieredStorage implements RemoteStorageManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(S3TieredStorage.class);
+
+    public static final String SEGMENT_SUFFIX = ".log";
+    public static final String OFFSET_INDEX_SUFFIX = "_offset.index";
+    public static final String TIME_INDEX_SUFFIX = "_time.index";
+    public static final String TX_INDEX_SUFFIX = "_tx.index";
+    public static final String PRODUCER_SNAPSHOT_SUFFIX = "_producer.snapshot";
+    public static final String LEADER_EPOCH_SUFFIX = "_leader.epoch";
+
+    private AmazonS3 s3Client;
+    private String bucketName;
+    private int fetchMaxBytes;
+    private String objectPrefix;
+
+    @Override
+    public void configure(final Map<String, ?> configs) {
+        final S3TieredStorageConfig config = new S3TieredStorageConfig(configs);
+        s3Client = config.s3Client();
+        bucketName = config.bucketName();
+        fetchMaxBytes = config.fetchMaxBytes();
+        objectPrefix = config.objectPrefix();
+    }
+
+    @Override
+    public void copyLogSegmentData(
+        final RemoteLogSegmentMetadata remoteLogSegmentMetadata,
+        final LogSegmentData logSegmentData
+    ) throws RemoteStorageException {
+        try {
+            final ObjectMetadata segmentPutMetadata = new ObjectMetadata();
+            segmentPutMetadata.setContentLength(Files.size(logSegmentData.logSegment()));
+            final PutObjectRequest segmentPutRequest = new PutObjectRequest(
+                bucketName,
+                segmentKey(remoteLogSegmentMetadata),
+                Files.newInputStream(logSegmentData.logSegment()),
+                segmentPutMetadata);
+            s3Client.putObject(segmentPutRequest);
+
+            final ObjectMetadata offsetPutMetadata = new ObjectMetadata();
+            offsetPutMetadata.setContentLength(Files.size(logSegmentData.offsetIndex()));
+            final PutObjectRequest offsetPutRequest = new PutObjectRequest(
+                bucketName,
+                indexKey(remoteLogSegmentMetadata, IndexType.OFFSET),
+                Files.newInputStream(logSegmentData.offsetIndex()),
+                offsetPutMetadata);
+            s3Client.putObject(offsetPutRequest);
+
+            final ObjectMetadata timePutMetadata = new ObjectMetadata();
+            timePutMetadata.setContentLength(Files.size(logSegmentData.timeIndex()));
+            final PutObjectRequest timePutRequest = new PutObjectRequest(
+                bucketName,
+                indexKey(remoteLogSegmentMetadata, IndexType.TIMESTAMP),
+                Files.newInputStream(logSegmentData.timeIndex()),
+                timePutMetadata);
+            s3Client.putObject(timePutRequest);
+
+            if (logSegmentData.transactionIndex().isPresent()) {
+                final ObjectMetadata txPutMetadata = new ObjectMetadata();
+                txPutMetadata.setContentLength(Files.size(logSegmentData.transactionIndex().get()));
+                final PutObjectRequest txPutRequest = new PutObjectRequest(
+                    bucketName,
+                    indexKey(remoteLogSegmentMetadata, IndexType.TRANSACTION),
+                    Files.newInputStream(logSegmentData.transactionIndex().get()),
+                    txPutMetadata);
+                s3Client.putObject(txPutRequest);
+            }
+
+            final ObjectMetadata prodPutMetadata = new ObjectMetadata();
+            prodPutMetadata.setContentLength(Files.size(logSegmentData.producerSnapshotIndex()));
+            final PutObjectRequest prodPutRequest = new PutObjectRequest(
+                bucketName,
+                indexKey(remoteLogSegmentMetadata, IndexType.PRODUCER_SNAPSHOT),
+                Files.newInputStream(logSegmentData.producerSnapshotIndex()),
+                prodPutMetadata);
+            s3Client.putObject(prodPutRequest);
+
+            final ObjectMetadata leaderEpochPutMetadata = new ObjectMetadata();
+            final int leaderEpochSize = logSegmentData.leaderEpochIndex().remaining();
+            leaderEpochPutMetadata.setContentLength(leaderEpochSize);
+            final PutObjectRequest leaderEpochPutRequest = new PutObjectRequest(
+                bucketName,
+                indexKey(remoteLogSegmentMetadata, IndexType.LEADER_EPOCH),
+                new ByteBufferInputStream(logSegmentData.leaderEpochIndex()),
+                leaderEpochPutMetadata);
+            s3Client.putObject(leaderEpochPutRequest);
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public InputStream fetchLogSegment(
+        final RemoteLogSegmentMetadata remoteLogSegmentMetadata,
+        final int offset
+    ) throws RemoteStorageException {
+        final String key = segmentKey(remoteLogSegmentMetadata);
+        try {
+            final GetObjectRequest request = new GetObjectRequest(bucketName, key);
+            request.setRange(offset);
+            final S3Object s3Object = s3Client.getObject(request);
+            LOG.info("Fetched segment: {} with length {}", key, s3Object.getObjectContent().available());
+            return s3Object.getObjectContent();
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public InputStream fetchLogSegment(
+        final RemoteLogSegmentMetadata remoteLogSegmentMetadata,
+        final int startOffset,
+        final int requestedEndOffset
+    ) throws RemoteStorageException {
+        final String key = segmentKey(remoteLogSegmentMetadata);
+        final int endOffset = Math.min(requestedEndOffset, remoteLogSegmentMetadata.segmentSizeInBytes() - 1);
+        LOG.info("Fetch segment: {} at offsets: [{}, {}]", key, startOffset, endOffset);
+        try {
+            final GetObjectRequest request = new GetObjectRequest(bucketName, key);
+            request.setRange(startOffset, endOffset);
+            final S3Object s3Object = s3Client.getObject(request);
+            LOG.info("Fetched segment: {} with length {}", key, s3Object.getObjectContent().available());
+            return s3Object.getObjectContent();
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public InputStream fetchIndex(
+        final RemoteLogSegmentMetadata remoteLogSegmentMetadata,
+        final IndexType indexType
+    ) throws RemoteStorageException {
+        final String key = indexKey(remoteLogSegmentMetadata, indexType);
+        LOG.info("Fetch index ({}): {}", indexType.name(), key);
+        final GetObjectRequest request = new GetObjectRequest(bucketName, key);
+        try {
+            final S3Object s3Object = s3Client.getObject(request);
+            return s3Object.getObjectContent();
+        } catch (final AmazonS3Exception e) {
+            LOG.warn(e.getMessage());
+            if (e.getMessage().startsWith("The specified key does not exist.")) {
+                return null;
+            }
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void deleteLogSegmentData(
+        final RemoteLogSegmentMetadata remoteLogSegmentMetadata
+    ) throws RemoteStorageException {
+        final DeleteObjectsRequest request = new DeleteObjectsRequest(bucketName);
+        final List<DeleteObjectsRequest.KeyVersion> keys = objectSet(remoteLogSegmentMetadata).values()
+            .stream()
+            .map(DeleteObjectsRequest.KeyVersion::new)
+            .collect(Collectors.toList());
+        request.setKeys(keys);
+        s3Client.deleteObjects(request);
+    }
+
+    Map<String, String> objectSet(final RemoteLogSegmentMetadata remoteLogSegmentMetadata) {
+        final Map<String, String> set = new HashMap<>();
+        set.put("SEGMENT", segmentKey(remoteLogSegmentMetadata));
+        for (final IndexType indexType : IndexType.values()) {
+            set.put(indexType.name(), indexKey(remoteLogSegmentMetadata, indexType));
+        }
+        return set;
+    }
+
+    private String segmentKey(final RemoteLogSegmentMetadata remoteLogSegmentMetadata) {
+        return key(remoteLogSegmentMetadata, SEGMENT_SUFFIX);
+    }
+
+    private String indexKey(final RemoteLogSegmentMetadata remoteLogSegmentMetadata, final IndexType indexType) {
+        return key(remoteLogSegmentMetadata, indexSuffix(indexType));
+    }
+
+    private String key(final RemoteLogSegmentMetadata remoteLogSegmentMetadata, final String suffix) {
+        return prefix(remoteLogSegmentMetadata)
+            + remoteLogSegmentMetadata.remoteLogSegmentId().id().toString()
+            + suffix;
+    }
+
+    private String prefix(final RemoteLogSegmentMetadata remoteLogSegmentMetadata) {
+        return objectPrefix + remoteLogSegmentMetadata.topicIdPartition().topicPartition().topic()
+            + "-" + remoteLogSegmentMetadata.topicIdPartition().topicId().toString()
+            + "/" + remoteLogSegmentMetadata.topicIdPartition().topicPartition().partition()
+            + "/";
+    }
+
+    static String indexSuffix(final IndexType indexType) {
+        switch (indexType) {
+            case OFFSET:
+                return OFFSET_INDEX_SUFFIX;
+            case TIMESTAMP:
+                return TIME_INDEX_SUFFIX;
+            case TRANSACTION:
+                return TX_INDEX_SUFFIX;
+            case LEADER_EPOCH:
+                return LEADER_EPOCH_SUFFIX;
+            case PRODUCER_SNAPSHOT:
+                return PRODUCER_SNAPSHOT_SUFFIX;
+            default:
+                throw new IllegalStateException("No index type found");
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+}

--- a/s3-minimal/src/main/java/io/aiven/kafka/tieredstorage/s3/S3TieredStorageConfig.java
+++ b/s3-minimal/src/main/java/io/aiven/kafka/tieredstorage/s3/S3TieredStorageConfig.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2021 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.s3;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.types.Password;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+public class S3TieredStorageConfig extends AbstractConfig {
+
+    public static final String S3_BUCKET_NAME_CONFIG = "s3.bucket.name";
+    private static final String S3_BUCKET_NAME_DOC = "The S3 Bucket.";
+
+    public static final String S3_FETCH_MAX_BYTES_CONFIG = "s3.fetch.max.bytes";
+    public static final int S3_FETCH_MAX_BYTES_DEFAULT = 10_000_000; // 10MB
+    private static final String S3_FETCH_MAX_BYTES_DOC = "Max bytes to fetch when no boundaries are provided.";
+
+    public static final String S3_OBJECT_PREFIX_CONFIG = "s3.object.prefix";
+
+    private static final String S3_OBJECT_PREFIX_DOC = "The S3 prefix";
+    public static final String S3_ENDPOINT_URL_CONFIG = "s3.endpoint.url";
+
+    private static final String S3_ENDPOINT_URL_DOC = "Custom S3 Endpoint URL";
+
+    private static final String GROUP_AWS = "AWS";
+    public static final String AWS_REGION_CONFIG = "s3.aws.region";
+    private static final String AWS_REGION_DEFAULT = Regions.DEFAULT_REGION.getName();
+    private static final String AWS_REGION_DOC = "The AWS region.";
+    public static final String AWS_CREDENTIALS_PROVIDER_CLASS_CONFIG = "s3.aws.credentials.provider.class";
+    private static final Class<? extends AWSCredentialsProvider> AWS_CREDENTIALS_PROVIDER_CLASS_DEFAULT =
+        DefaultAWSCredentialsProviderChain.class;
+    private static final String AWS_CREDENTIALS_PROVIDER_CLASS_DOC = "The credentials provider to use for "
+        + "authentication to AWS. If not set, AWS SDK uses the default "
+        + "com.amazonaws.auth.DefaultAWSCredentialsProviderChain";
+    public static final String AWS_ACCESS_KEY_ID_CONFIG = "s3.aws.access.key.id";
+    private static final String AWS_ACCESS_KEY_ID_DOC = "AWS Access Key ID";
+
+    public static final String AWS_SECRET_ACCESS_KEY_CONFIG = "s3.aws.secret.access.key";
+    private static final String AWS_SECRET_ACCESS_KEY_DOC = "AWS Secret Access Key";
+
+    private static final ConfigDef CONFIG = new ConfigDef();
+
+    static {
+        CONFIG
+            .define(
+                S3_BUCKET_NAME_CONFIG,
+                ConfigDef.Type.STRING,
+                ConfigDef.NO_DEFAULT_VALUE,
+                new ConfigDef.NonEmptyString(),
+                ConfigDef.Importance.HIGH,
+                S3_BUCKET_NAME_DOC)
+            .define(
+                S3_FETCH_MAX_BYTES_CONFIG,
+                ConfigDef.Type.INT,
+                S3_FETCH_MAX_BYTES_DEFAULT,
+                ConfigDef.Importance.MEDIUM,
+                S3_FETCH_MAX_BYTES_DOC
+            )
+            .define(
+                S3_OBJECT_PREFIX_CONFIG,
+                ConfigDef.Type.STRING,
+                "",
+                ConfigDef.Importance.MEDIUM,
+                S3_OBJECT_PREFIX_DOC)
+            .define(
+                S3_ENDPOINT_URL_CONFIG,
+                ConfigDef.Type.STRING,
+                null,
+                ConfigDef.Importance.LOW,
+                S3_ENDPOINT_URL_DOC);
+
+        // AWS specific configs
+        int awsGroupCounter = 0;
+        CONFIG
+            .define(
+                AWS_REGION_CONFIG,
+                ConfigDef.Type.STRING,
+                AWS_REGION_DEFAULT,
+                new RegionValidator(),
+                ConfigDef.Importance.MEDIUM,
+                AWS_REGION_DOC,
+                GROUP_AWS,
+                awsGroupCounter++,
+                ConfigDef.Width.NONE,
+                AWS_REGION_CONFIG
+            )
+            .define(
+                AWS_CREDENTIALS_PROVIDER_CLASS_CONFIG,
+                ConfigDef.Type.CLASS,
+                AWS_CREDENTIALS_PROVIDER_CLASS_DEFAULT,
+                new CredentialsProviderValidator(),
+                ConfigDef.Importance.LOW,
+                AWS_CREDENTIALS_PROVIDER_CLASS_DOC,
+                GROUP_AWS,
+                awsGroupCounter++,
+                ConfigDef.Width.NONE,
+                AWS_CREDENTIALS_PROVIDER_CLASS_CONFIG,
+                new ConfigDef.Recommender() {
+                    @Override
+                    public List<Object> validValues(final String s, final Map<String, Object> map) {
+                        return Collections.emptyList();
+                    }
+
+                    @Override
+                    public boolean visible(final String s, final Map<String, Object> map) {
+                        final String credentialsProvider = (String) map.get("S3_CREDENTIALS_PROVIDER_CLASS_CONFIG");
+                        try {
+                            if (Class.forName(credentialsProvider)
+                                .isAssignableFrom(AWSStaticCredentialsProvider.class)) {
+                                return s.equals(AWS_ACCESS_KEY_ID_CONFIG) || s.equals(AWS_SECRET_ACCESS_KEY_CONFIG);
+                            }
+                        } catch (final ClassNotFoundException e) {
+                            e.printStackTrace();
+                        }
+                        return false;
+                    }
+                })
+            .define(
+                AWS_ACCESS_KEY_ID_CONFIG,
+                ConfigDef.Type.PASSWORD,
+                null,
+                new NonEmptyPassword(),
+                ConfigDef.Importance.MEDIUM,
+                AWS_ACCESS_KEY_ID_DOC,
+                GROUP_AWS,
+                awsGroupCounter++,
+                ConfigDef.Width.NONE,
+                AWS_ACCESS_KEY_ID_CONFIG)
+            .define(
+                AWS_SECRET_ACCESS_KEY_CONFIG,
+                ConfigDef.Type.PASSWORD,
+                null,
+                new NonEmptyPassword(),
+                ConfigDef.Importance.MEDIUM,
+                AWS_SECRET_ACCESS_KEY_DOC,
+                GROUP_AWS,
+                awsGroupCounter++,
+                ConfigDef.Width.NONE,
+                AWS_SECRET_ACCESS_KEY_CONFIG
+            );
+    }
+
+    public S3TieredStorageConfig(final Map<String, ?> props) {
+        super(CONFIG, props);
+    }
+
+    AmazonS3 s3Client() {
+        return s3Client(awsCredentialsProvider());
+    }
+
+    AmazonS3 s3Client(final AWSCredentialsProvider credentialsProvider) {
+        AmazonS3ClientBuilder s3ClientBuilder = AmazonS3ClientBuilder.standard();
+        final String s3ServiceEndpoint = getString(S3_ENDPOINT_URL_CONFIG);
+        final String region = getString(AWS_REGION_CONFIG);
+        if (s3ServiceEndpoint == null) {
+            s3ClientBuilder = s3ClientBuilder.withRegion(region);
+        } else {
+            final AwsClientBuilder.EndpointConfiguration endpointConfiguration =
+                new AwsClientBuilder.EndpointConfiguration(s3ServiceEndpoint, region);
+            s3ClientBuilder = s3ClientBuilder.withEndpointConfiguration(endpointConfiguration)
+                .withPathStyleAccessEnabled(true);
+        }
+        s3ClientBuilder.setCredentials(credentialsProvider);
+        return s3ClientBuilder.build();
+    }
+
+    public AWSCredentialsProvider awsCredentialsProvider() {
+        try {
+            @SuppressWarnings("unchecked") final Class<? extends AWSCredentialsProvider> providerClass =
+                (Class<? extends AWSCredentialsProvider>) getClass(AWS_CREDENTIALS_PROVIDER_CLASS_CONFIG);
+            if (providerClass == null) {
+                return null;
+            }
+            if (providerClass.isAssignableFrom(AWSStaticCredentialsProvider.class)) {
+                return new AWSStaticCredentialsProvider(awsCredentials());
+            }
+            return providerClass.getDeclaredConstructor().newInstance();
+        } catch (final ReflectiveOperationException e) {
+            throw new KafkaException(e);
+        }
+    }
+
+    public AWSCredentials awsCredentials() {
+        return new BasicAWSCredentials(getPassword(AWS_ACCESS_KEY_ID_CONFIG).value(),
+            getPassword(AWS_SECRET_ACCESS_KEY_CONFIG).value());
+    }
+
+    public String bucketName() {
+        return getString(S3_BUCKET_NAME_CONFIG);
+    }
+
+    public String objectPrefix() {
+        return getString(S3_OBJECT_PREFIX_CONFIG);
+    }
+
+    public int fetchMaxBytes() {
+        return getInt(S3_FETCH_MAX_BYTES_CONFIG);
+    }
+
+    private static class RegionValidator implements ConfigDef.Validator {
+        @Override
+        public void ensureValid(final String name, final Object value) {
+            final String regionStr = (String) value;
+            try {
+                Regions.fromName(regionStr);
+            } catch (final IllegalArgumentException e) {
+                throw new ConfigException(name, value);
+            }
+        }
+    }
+
+    private static class CredentialsProviderValidator implements ConfigDef.Validator {
+        @Override
+        public void ensureValid(final String name, final Object value) {
+            if (value == null) {
+                return;
+            }
+
+            final Class<?> providerClass = (Class<?>) value;
+            if (!AWSCredentialsProvider.class.isAssignableFrom(providerClass)) {
+                throw new ConfigException(name, value, "Class must extend " + AWSCredentialsProvider.class);
+            }
+        }
+    }
+
+    private static class NonEmptyPassword implements ConfigDef.Validator {
+
+        @Override
+        public void ensureValid(final String name, final Object value) {
+            if (Objects.isNull(value)) {
+                return;
+            }
+            final var pwd = (Password) value;
+            if (pwd.value() == null || pwd.value().isBlank()) {
+                throw new ConfigException(name, pwd, "Password must be non-empty");
+            }
+
+        }
+
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,5 +16,6 @@
 
 rootProject.name = 'kafka-tiered-storage'
 include 's3'
+include 's3-minimal'
 include 'commons'
 


### PR DESCRIPTION
Depends on #169 

Implements an S3 RSM directly using the S3 client. 

The purpose of this plugin implementation is to 
- gain experience with the S3 client
- benchmark the features included on `new-implementation` branch (e.g. chunking, encryption, compression) against this to evaluate performance. 

Not meant to be merged at the moment, as main work is going on new-implementation branch.