### PR TITLE
fix: remove parent directories to mimic s3 behaviour

### DIFF
--- a/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorage.java
+++ b/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorage.java
@@ -74,8 +74,8 @@ class FileSystemStorage implements FileUploader, FileFetcher, FileDeleter {
 
         final Path path = fsRoot.resolve(key);
         final long fileSize = Files.size(path);
-        if (to > fileSize) {
-            throw new IllegalArgumentException("to cannot be bigger than file size, to="
+        if (to >= fileSize) {
+            throw new IllegalArgumentException("position 'to' cannot be equal or higher than the file size, to="
                 + to + ", file size=" + fileSize + " given");
         }
 

--- a/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorage.java
+++ b/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorage.java
@@ -26,20 +26,28 @@ import io.aiven.kafka.tieredstorage.commons.storage.FileDeleter;
 import io.aiven.kafka.tieredstorage.commons.storage.FileFetcher;
 import io.aiven.kafka.tieredstorage.commons.storage.FileUploader;
 
+import org.apache.commons.io.file.PathUtils;
 import org.apache.commons.io.input.BoundedInputStream;
 
 class FileSystemStorage implements FileUploader, FileFetcher, FileDeleter {
-    private final String fsRoot;
+    private final Path fsRoot;
     private final boolean overwrites;
 
     FileSystemStorage(final String fsRoot, final boolean overwrites) {
+        this(Path.of(fsRoot), overwrites);
+    }
+
+    FileSystemStorage(final Path fsRoot, final boolean overwrites) {
+        if (!Files.isDirectory(fsRoot) || !Files.isWritable(fsRoot)) {
+            throw new IllegalArgumentException(fsRoot + " must be a writable directory");
+        }
         this.fsRoot = fsRoot;
         this.overwrites = overwrites;
     }
 
     @Override
     public void upload(final InputStream inputStream, final String key) throws IOException {
-        final Path path = Path.of(fsRoot, key);
+        final Path path = fsRoot.resolve(key);
         if (!overwrites && Files.exists(path)) {
             throw new IOException("File " + path + " already exists");
         }
@@ -51,7 +59,7 @@ class FileSystemStorage implements FileUploader, FileFetcher, FileDeleter {
 
     @Override
     public InputStream fetch(final String key) throws IOException {
-        final Path path = Path.of(fsRoot, key);
+        final Path path = fsRoot.resolve(key);
         return Files.newInputStream(path);
     }
 
@@ -64,19 +72,28 @@ class FileSystemStorage implements FileUploader, FileFetcher, FileDeleter {
             throw new IllegalArgumentException("from cannot be more than to, from=" + from + ", to=" + to + " given");
         }
 
-        final Path path = Path.of(fsRoot, key);
+        final Path path = fsRoot.resolve(key);
         final long fileSize = Files.size(path);
         if (to > fileSize) {
             throw new IllegalArgumentException("to cannot be bigger than file size, to="
                 + to + ", file size=" + fileSize + " given");
         }
-        final InputStream result = new BoundedInputStream(Files.newInputStream(path), to + 1);
+
+        final int size = to + 1;
+        final InputStream result = new BoundedInputStream(Files.newInputStream(path), size);
         result.skip(from);
         return result;
     }
 
     @Override
     public void delete(final String key) throws IOException {
-        Files.delete(Path.of(fsRoot, key));
+        final Path path = fsRoot.resolve(key);
+        Files.deleteIfExists(path);
+        Path parent = path.getParent();
+        while (parent != null && Files.isDirectory(parent) && !parent.equals(fsRoot)
+            && PathUtils.isEmptyDirectory(parent)) {
+            Files.deleteIfExists(parent);
+            parent = parent.getParent();
+        }
     }
 }

--- a/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageFactoryTest.java
+++ b/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageFactoryTest.java
@@ -96,6 +96,6 @@ class FileSystemStorageFactoryTest {
 
         osFactory.fileDeleter().delete("aaa/0.log.txt");
 
-        assertThat(new File(fsRoot, "aaa")).isEmptyDirectory();
+        assertThat(new File(fsRoot, "aaa")).doesNotExist();
     }
 }

--- a/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageTest.java
+++ b/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.commons.storage.filesystem;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FileSystemStorageTest {
+
+    static final String TOPIC_PARTITION_SEGMENT_KEY = "topic/partition/log";
+
+    @TempDir
+    Path root;
+
+    @Test
+    void testRootCannotBeAFile() throws IOException {
+        final Path wrongRoot = root.resolve("file_instead");
+        Files.writeString(wrongRoot, "Wrong root");
+
+        assertThatThrownBy(() -> new FileSystemStorage(wrongRoot, true))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(wrongRoot + " must be a writable directory");
+    }
+
+    @Test
+    void testRootCannotBeNonWritableDirectory() throws IOException {
+        final Path nonWritableDir = root.resolve("non_writable");
+        Files.createDirectory(nonWritableDir).toFile().setReadOnly();
+
+        assertThatThrownBy(() -> new FileSystemStorage(nonWritableDir, true))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(nonWritableDir + " must be a writable directory");
+    }
+
+    @Test
+    void testUploadANewFile() throws IOException {
+        final FileSystemStorage storage = new FileSystemStorage(root, false);
+        final String content = "content";
+        storage.upload(new ByteArrayInputStream(content.getBytes()), TOPIC_PARTITION_SEGMENT_KEY);
+
+        assertThat(root.resolve(TOPIC_PARTITION_SEGMENT_KEY)).hasContent(content);
+    }
+
+    @Test
+    void testUploadFailsWhenFileExists() throws IOException {
+        final Path previous = root.resolve(TOPIC_PARTITION_SEGMENT_KEY);
+        Files.createDirectories(previous.getParent());
+        Files.writeString(previous, "previous");
+        final FileSystemStorage storage = new FileSystemStorage(root, false);
+        final String content = "content";
+
+        assertThatThrownBy(() ->
+            storage.upload(new ByteArrayInputStream(content.getBytes()), TOPIC_PARTITION_SEGMENT_KEY))
+            .isInstanceOf(IOException.class)
+            .hasMessage("File " + previous + " already exists");
+    }
+
+    @Test
+    void testUploadWithOverridesWhenFileExists() throws IOException {
+        final Path previous = root.resolve(TOPIC_PARTITION_SEGMENT_KEY);
+        Files.createDirectories(previous.getParent());
+        Files.writeString(previous, "previous");
+        final FileSystemStorage storage = new FileSystemStorage(root, true);
+        final String content = "content";
+        storage.upload(new ByteArrayInputStream(content.getBytes()), TOPIC_PARTITION_SEGMENT_KEY);
+        assertThat(previous).hasContent(content);
+    }
+
+    @Test
+    void testFetchAll() throws IOException {
+        final String content = "content";
+        final Path keyPath = root.resolve(TOPIC_PARTITION_SEGMENT_KEY);
+        Files.createDirectories(keyPath.getParent());
+        Files.writeString(keyPath, content);
+        final FileSystemStorage storage = new FileSystemStorage(root, true);
+
+        try (final InputStream fetch = storage.fetch(TOPIC_PARTITION_SEGMENT_KEY)) {
+            assertThat(fetch).hasContent(content);
+        }
+    }
+
+    @Test
+    void testFetchWithOffsetRange() throws IOException {
+        final String content = "AABBBBAA";
+        final int from = 2;
+        final int to = 6;
+        final String range = content.substring(from, to + 1); // exclusive
+        final Path keyPath = root.resolve(TOPIC_PARTITION_SEGMENT_KEY);
+        Files.createDirectories(keyPath.getParent());
+        Files.writeString(keyPath, content);
+        final FileSystemStorage storage = new FileSystemStorage(root, true);
+
+        try (final InputStream fetch = storage.fetch(TOPIC_PARTITION_SEGMENT_KEY, from, to)) {
+            assertThat(fetch).hasContent(range);
+        }
+    }
+
+    @Test
+    void testFetchWithFailsWithWrongOffsets() {
+        final FileSystemStorage storage = new FileSystemStorage(root, true);
+
+        assertThatThrownBy(() -> storage.fetch(TOPIC_PARTITION_SEGMENT_KEY, -1, 1))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("from cannot be negative, -1 given");
+        assertThatThrownBy(() -> storage.fetch(TOPIC_PARTITION_SEGMENT_KEY, 2, 1))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("from cannot be more than to, from=2, to=1 given");
+    }
+
+    @Test
+    void testFetchWithOffsetRangeLargerThanFileSize() throws IOException {
+        final String content = "content";
+        final Path keyPath = root.resolve(TOPIC_PARTITION_SEGMENT_KEY);
+        Files.createDirectories(keyPath.getParent());
+        Files.writeString(keyPath, content);
+        final FileSystemStorage storage = new FileSystemStorage(root, true);
+
+        assertThatThrownBy(() -> storage.fetch(TOPIC_PARTITION_SEGMENT_KEY, 0, content.length() + 1))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("to cannot be bigger than file size, to=8, file size=7 given");
+    }
+
+    @Test
+    void testDelete() throws IOException {
+        final Path keyPath = root.resolve(TOPIC_PARTITION_SEGMENT_KEY);
+        Files.createDirectories(keyPath.getParent());
+        Files.writeString(keyPath, "test");
+        final FileSystemStorage storage = new FileSystemStorage(root, false);
+        storage.delete(TOPIC_PARTITION_SEGMENT_KEY);
+
+        assertThat(keyPath).doesNotExist(); // segment key
+        assertThat(keyPath.getParent()).doesNotExist(); // partition key
+        assertThat(keyPath.getParent().getParent()).doesNotExist(); // partition key
+        assertThat(root).exists();
+    }
+
+    @Test
+    void testDeleteDoesNotRemoveParentDir() throws IOException {
+        final String parent = "parent";
+        final String key = "key";
+        final Path parentPath = root.resolve(parent);
+        Files.createDirectories(parentPath);
+        Files.writeString(parentPath.resolve("another"), "test");
+        final Path keyPath = parentPath.resolve(key);
+        Files.writeString(keyPath, "test");
+        final FileSystemStorage storage = new FileSystemStorage(root, false);
+        storage.delete(parent + "/" + key);
+
+        assertThat(keyPath).doesNotExist();
+        assertThat(parentPath).exists();
+        assertThat(root).exists();
+    }
+}


### PR DESCRIPTION
When a directory is emptied on S3, the parent keys are removed until an object is found