### PR TITLE
refactor: move object key prefix as a field

### DIFF
--- a/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/ObjectKey.java
+++ b/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/ObjectKey.java
@@ -61,6 +61,12 @@ public final class ObjectKey {
         }
     }
 
+    private final String prefix;
+
+    public ObjectKey(final String prefix) {
+        this.prefix = prefix;
+    }
+
     /**
      * Creates the object key/path in the following format:
      *
@@ -69,11 +75,9 @@ public final class ObjectKey {
      * </pre>
      *
      * <p>For example:
-     * <code>someprefix/topic-MWJ6FHTfRYy67jzwZdeqSQ/7/00000000000000001234-tqimKeZwStOEOwRzT3L5oQ.log</code>
+     * {@code someprefix/topic-MWJ6FHTfRYy67jzwZdeqSQ/7/00000000000000001234-tqimKeZwStOEOwRzT3L5oQ.log}
      */
-    public static String key(final String prefix,
-                             final RemoteLogSegmentMetadata remoteLogSegmentMetadata,
-                             final Suffix suffix) {
+    public String key(final RemoteLogSegmentMetadata remoteLogSegmentMetadata, final Suffix suffix) {
         Objects.requireNonNull(remoteLogSegmentMetadata, "remoteLogSegmentMetadata cannot be null");
         Objects.requireNonNull(suffix, "suffix cannot be null");
 

--- a/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/ObjectKeyTest.java
+++ b/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/ObjectKeyTest.java
@@ -40,31 +40,32 @@ class ObjectKeyTest {
 
     @Test
     void test() {
-        assertThat(ObjectKey.key("prefix/", REMOTE_LOG_SEGMENT_METADATA, ObjectKey.Suffix.LOG))
+        final ObjectKey objectKey = new ObjectKey("prefix/");
+        assertThat(objectKey.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKey.Suffix.LOG))
             .isEqualTo(
                 "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
                     + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.log");
-        assertThat(ObjectKey.key("prefix/", REMOTE_LOG_SEGMENT_METADATA, ObjectKey.Suffix.OFFSET_INDEX))
+        assertThat(objectKey.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKey.Suffix.OFFSET_INDEX))
             .isEqualTo(
                 "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
                     + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.index");
-        assertThat(ObjectKey.key("prefix/", REMOTE_LOG_SEGMENT_METADATA, ObjectKey.Suffix.TIME_INDEX))
+        assertThat(objectKey.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKey.Suffix.TIME_INDEX))
             .isEqualTo(
                 "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
                     + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.timeindex");
-        assertThat(ObjectKey.key("prefix/", REMOTE_LOG_SEGMENT_METADATA, ObjectKey.Suffix.PRODUCER_SNAPSHOT))
+        assertThat(objectKey.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKey.Suffix.PRODUCER_SNAPSHOT))
             .isEqualTo(
                 "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
                     + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.snapshot");
-        assertThat(ObjectKey.key("prefix/", REMOTE_LOG_SEGMENT_METADATA, ObjectKey.Suffix.TXN_INDEX))
+        assertThat(objectKey.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKey.Suffix.TXN_INDEX))
             .isEqualTo(
                 "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
                     + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.txnindex");
-        assertThat(ObjectKey.key("prefix/", REMOTE_LOG_SEGMENT_METADATA, ObjectKey.Suffix.LEADER_EPOCH_CHECKPOINT))
+        assertThat(objectKey.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKey.Suffix.LEADER_EPOCH_CHECKPOINT))
             .isEqualTo(
                 "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
                     + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.leader-epoch-checkpoint");
-        assertThat(ObjectKey.key("prefix/", REMOTE_LOG_SEGMENT_METADATA, ObjectKey.Suffix.MANIFEST))
+        assertThat(objectKey.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKey.Suffix.MANIFEST))
             .isEqualTo(
                 "prefix/topic-AAAAAAAAAAAAAAAAAAAAAQ/7/"
                     + "00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.rsm-manifest");
@@ -72,7 +73,8 @@ class ObjectKeyTest {
 
     @Test
     void nullPrefix() {
-        assertThat(ObjectKey.key(null, REMOTE_LOG_SEGMENT_METADATA, ObjectKey.Suffix.LOG))
+        final ObjectKey objectKey = new ObjectKey(null);
+        assertThat(objectKey.key(REMOTE_LOG_SEGMENT_METADATA, ObjectKey.Suffix.LOG))
             .isEqualTo(
                 "topic-AAAAAAAAAAAAAAAAAAAAAQ/7/00000000000000001234-AAAAAAAAAAAAAAAAAAAAAA.log");
     }


### PR DESCRIPTION
Prefix is a pre-requisite to supply an object key, moving it as a field to avoid passing it on every call
