### PR TITLE
Don't allow originalChunkSize to be 0

### DIFF
--- a/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/manifest/index/AbstractChunkIndex.java
+++ b/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/manifest/index/AbstractChunkIndex.java
@@ -35,13 +35,13 @@ public abstract class AbstractChunkIndex implements ChunkIndex {
                                  final int originalFileSize,
                                  final int finalTransformedChunkSize,
                                  final int chunkCount) {
-        checkSize(originalChunkSize, "Original chunk size");
+        checkSizePositive(originalChunkSize, "Original chunk size");
         this.originalChunkSize = originalChunkSize;
 
-        checkSize(originalFileSize, "Original file size");
+        checkSizeNonNegative(originalFileSize, "Original file size");
         this.originalFileSize = originalFileSize;
 
-        checkSize(finalTransformedChunkSize, "Final transformed chunk size");
+        checkSizeNonNegative(finalTransformedChunkSize, "Final transformed chunk size");
         this.finalTransformedChunkSize = finalTransformedChunkSize;
 
         this.chunkCount = chunkCount;
@@ -115,10 +115,17 @@ public abstract class AbstractChunkIndex implements ChunkIndex {
 
     protected abstract int transformedChunkSize(final int chunkI);
 
-    protected final void checkSize(final int size, final String name) {
+    protected static void checkSizeNonNegative(final int size, final String name) {
         if (size < 0) {
             throw new IllegalArgumentException(
                 name + " must be non-negative, " + size + " given");
+        }
+    }
+
+    protected static void checkSizePositive(final int size, final String name) {
+        if (size <= 0) {
+            throw new IllegalArgumentException(
+                name + " must be positive, " + size + " given");
         }
     }
 

--- a/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/manifest/index/FixedSizeChunkIndex.java
+++ b/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/manifest/index/FixedSizeChunkIndex.java
@@ -67,13 +67,14 @@ public class FixedSizeChunkIndex extends AbstractChunkIndex {
         super(originalChunkSize, originalFileSize, finalTransformedChunkSize,
             chunkCount(originalChunkSize, originalFileSize));
 
-        checkSize(transformedChunkSize, "Transformed chunk size");
+        checkSizeNonNegative(transformedChunkSize, "Transformed chunk size");
         this.transformedChunkSize = transformedChunkSize;
 
         chunks = materializeChunks();
     }
 
     private static int chunkCount(final int originalChunkSize, final int originalFileSize) {
+        checkSizePositive(originalChunkSize, "Original chunk size");
         // ceil
         return originalFileSize % originalChunkSize == 0
             ? originalFileSize / originalChunkSize


### PR DESCRIPTION
This doesn't make sense and also cause division by 0 in `FixedSizeChunkIndex.chunkCount`
