### PR TITLE
feat: add KeyNotFoundException

### DIFF
--- a/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/KeyNotFoundException.java
+++ b/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/KeyNotFoundException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.commons.storage;
+
+public class KeyNotFoundException extends StorageBackEndException {
+
+    public KeyNotFoundException(final FileFetcher storage, final String key, final Exception e) {
+        super(getMessage(storage, key), e);
+    }
+
+    private static String getMessage(final FileFetcher storage, final String key) {
+        return "Key " + key + " does not exists in storage " + storage;
+    }
+}

--- a/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageTest.java
+++ b/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import io.aiven.kafka.tieredstorage.commons.storage.BytesRange;
+import io.aiven.kafka.tieredstorage.commons.storage.KeyNotFoundException;
 import io.aiven.kafka.tieredstorage.commons.storage.StorageBackEndException;
 
 import org.junit.jupiter.api.Test;
@@ -128,10 +129,20 @@ class FileSystemStorageTest {
         Files.writeString(keyPath, content);
         final FileSystemStorage storage = new FileSystemStorage(root);
 
-
         assertThatThrownBy(() -> storage.fetch(TOPIC_PARTITION_SEGMENT_KEY, BytesRange.of(0, content.length() + 1)))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("position 'to' cannot be higher than the file size, to=8, file size=7 given");
+    }
+
+    @Test
+    void testFetchNonExistingKey() {
+        final FileSystemStorage storage = new FileSystemStorage(root);
+        assertThatThrownBy(() -> storage.fetch("non-existing"))
+            .isInstanceOf(KeyNotFoundException.class)
+            .hasMessage("Key non-existing does not exists in storage " + storage);
+        assertThatThrownBy(() -> storage.fetch("non-existing", BytesRange.of(0, 1)))
+            .isInstanceOf(KeyNotFoundException.class)
+            .hasMessage("Key non-existing does not exists in storage " + storage);
     }
 
     @Test


### PR DESCRIPTION
Storage backends usually return exceptions when keys/files are not found. e.g. AmazonS3Exception 404 for S3, NoSuchFileException for FileSystem, etc. To wrap these into a common exception, this PR proposes a "KeyNotFoundException".

This exception should be catched and mapped to `RemoteResourceNotFoundException`