### PR TITLE
feat: add object range for fetcher

### DIFF
--- a/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/Chunk.java
+++ b/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/Chunk.java
@@ -16,6 +16,8 @@
 
 package io.aiven.kafka.tieredstorage.commons;
 
+import io.aiven.kafka.tieredstorage.commons.storage.BytesRange;
+
 public class Chunk {
     public final int id;
     public final int originalPosition;
@@ -57,6 +59,10 @@ public class Chunk {
             return false;
         }
         return transformedSize == that.transformedSize;
+    }
+
+    BytesRange range() {
+        return BytesRange.of(transformedPosition, transformedPosition + transformedSize);
     }
 
     @Override

--- a/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/BytesRange.java
+++ b/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/BytesRange.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.commons.storage;
+
+/**
+ * Byte range with from and to edges; where to cannot be less than from.
+ * inclusive/exclusive semantics are up to the consumer.
+ */
+public class BytesRange {
+    public final int from;
+    public final int to;
+
+    BytesRange(final int from, final int to) {
+        if (from < 0) {
+            throw new IllegalArgumentException("from cannot be negative, " + from + " given");
+        }
+        if (to < from) {
+            throw new IllegalArgumentException("to cannot be less than from, from=" + from + ", to=" + to + " given");
+        }
+        this.from = from;
+        this.to = to;
+    }
+
+    public static BytesRange of(final int from, final int to) {
+        return new BytesRange(from, to);
+    }
+}

--- a/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/FileFetcher.java
+++ b/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/FileFetcher.java
@@ -29,8 +29,7 @@ public interface FileFetcher {
     /**
      * Fetch file.
      * @param key file key.
-     * @param from start position, inclusive.
-     * @param to end position, inclusive.
+     * @param range start (inclusive)/end (exclusive) position
      */
-    InputStream fetch(String key, int from, int to) throws IOException;
+    InputStream fetch(String key, BytesRange range) throws IOException;
 }

--- a/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/storage/BytesRangeTest.java
+++ b/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/storage/BytesRangeTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.commons.storage;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BytesRangeTest {
+
+    @Test
+    void testProperRange() {
+        final BytesRange range = BytesRange.of(1, 2);
+        assertThat(range.from).isEqualTo(1);
+        assertThat(range.to).isEqualTo(2);
+    }
+
+    @Test
+    void testNegative() {
+        assertThatThrownBy(() -> BytesRange.of(-1, 1))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("from cannot be negative, -1 given");
+    }
+
+    @Test
+    void testFromLargerThanTo() {
+        assertThatThrownBy(() -> BytesRange.of(2, 1))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("to cannot be less than from, from=2, to=1 given");
+    }
+}

--- a/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageFactoryTest.java
+++ b/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageFactoryTest.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
+import io.aiven.kafka.tieredstorage.commons.storage.BytesRange;
 import io.aiven.kafka.tieredstorage.commons.storage.ObjectStorageFactory;
 
 import org.junit.jupiter.api.Test;
@@ -89,7 +90,8 @@ class FileSystemStorageFactoryTest {
             assertThat(r).isEqualTo("some file");
         }
 
-        try (final InputStream fetch = osFactory.fileFetcher().fetch("aaa/0.log.txt", 1, data.length - 2)) {
+        final BytesRange range = BytesRange.of(1, data.length - 2);
+        try (final InputStream fetch = osFactory.fileFetcher().fetch("aaa/0.log.txt", range)) {
             final String r = new String(fetch.readAllBytes());
             assertThat(r).isEqualTo("ome fi");
         }


### PR DESCRIPTION
Range validation should be in one place instead of each storage implementation.
