### PR TITLE
refactor: remove overwrite flag for FileSystem storage

### DIFF
--- a/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorage.java
+++ b/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorage.java
@@ -32,26 +32,17 @@ import org.apache.commons.io.input.BoundedInputStream;
 
 class FileSystemStorage implements FileUploader, FileFetcher, FileDeleter {
     private final Path fsRoot;
-    private final boolean overwrites;
 
-    FileSystemStorage(final String fsRoot, final boolean overwrites) {
-        this(Path.of(fsRoot), overwrites);
-    }
-
-    FileSystemStorage(final Path fsRoot, final boolean overwrites) {
+    FileSystemStorage(final Path fsRoot) {
         if (!Files.isDirectory(fsRoot) || !Files.isWritable(fsRoot)) {
             throw new IllegalArgumentException(fsRoot + " must be a writable directory");
         }
         this.fsRoot = fsRoot;
-        this.overwrites = overwrites;
     }
 
     @Override
     public void upload(final InputStream inputStream, final String key) throws IOException {
         final Path path = fsRoot.resolve(key);
-        if (!overwrites && Files.exists(path)) {
-            throw new IOException("File " + path + " already exists");
-        }
         Files.createDirectories(path.getParent());
         try (final OutputStream outputStream = Files.newOutputStream(path)) {
             inputStream.transferTo(outputStream);
@@ -93,7 +84,6 @@ class FileSystemStorage implements FileUploader, FileFetcher, FileDeleter {
     @Override
     public String toString() {
         return "FileSystemStorage{"
-            + "fsRoot=" + fsRoot
-            + ", overwrites=" + overwrites + '}';
+            + "fsRoot=" + fsRoot + '}';
     }
 }

--- a/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageConfig.java
+++ b/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageConfig.java
@@ -16,6 +16,7 @@
 
 package io.aiven.kafka.tieredstorage.commons.storage.filesystem;
 
+import java.nio.file.Path;
 import java.util.Map;
 
 import org.apache.kafka.common.config.AbstractConfig;
@@ -52,11 +53,7 @@ class FileSystemStorageConfig extends AbstractConfig {
         super(CONFIG, props);
     }
 
-    final String root() {
-        return getString(ROOT_CONFIG);
-    }
-
-    final boolean overwrites() {
-        return getBoolean(OVERWRITE_ENABLED_CONFIG);
+    final Path root() {
+        return Path.of(getString(ROOT_CONFIG));
     }
 }

--- a/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageFactory.java
+++ b/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageFactory.java
@@ -16,6 +16,7 @@
 
 package io.aiven.kafka.tieredstorage.commons.storage.filesystem;
 
+import java.nio.file.Path;
 import java.util.Map;
 
 import io.aiven.kafka.tieredstorage.commons.storage.FileDeleter;
@@ -24,28 +25,26 @@ import io.aiven.kafka.tieredstorage.commons.storage.FileUploader;
 import io.aiven.kafka.tieredstorage.commons.storage.ObjectStorageFactory;
 
 public class FileSystemStorageFactory implements ObjectStorageFactory {
-    private String root;
-    private boolean overwrites;
+    private Path root;
 
     @Override
     public void configure(final Map<String, ?> configs) {
         final FileSystemStorageConfig config = new FileSystemStorageConfig(configs);
         this.root = config.root();
-        this.overwrites = config.overwrites();
     }
 
     @Override
     public FileUploader fileUploader() {
-        return new FileSystemStorage(root, overwrites);
+        return new FileSystemStorage(root);
     }
 
     @Override
     public FileFetcher fileFetcher() {
-        return new FileSystemStorage(root, overwrites);
+        return new FileSystemStorage(root);
     }
 
     @Override
     public FileDeleter fileDeleter() {
-        return new FileSystemStorage(root, overwrites);
+        return new FileSystemStorage(root);
     }
 }

--- a/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageConfigTest.java
+++ b/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageConfigTest.java
@@ -16,11 +16,10 @@
 
 package io.aiven.kafka.tieredstorage.commons.storage.filesystem;
 
+import java.nio.file.Path;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,17 +29,6 @@ class FileSystemStorageConfigTest {
         final FileSystemStorageConfig config = new FileSystemStorageConfig(Map.of(
             "root", "."
         ));
-        assertThat(config.root()).isEqualTo(".");
-        assertThat(config.overwrites()).isFalse();
-    }
-
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void overwriteEnabledExplicit(final boolean overwriteEnabled) {
-        final FileSystemStorageConfig config = new FileSystemStorageConfig(Map.of(
-            "root", ".",
-            "overwrite.enabled", Boolean.toString(overwriteEnabled)
-        ));
-        assertThat(config.overwrites()).isEqualTo(overwriteEnabled);
+        assertThat(config.root()).isEqualTo(Path.of("."));
     }
 }

--- a/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageFactoryTest.java
+++ b/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageFactoryTest.java
@@ -20,7 +20,6 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
@@ -31,48 +30,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class FileSystemStorageFactoryTest {
-    @Test
-    void testNotAllowOverwriting(@TempDir final Path tempDir) throws IOException {
-        final File fsRoot = tempDir.toFile();
-        final ObjectStorageFactory osFactory = new FileSystemStorageFactory();
-        osFactory.configure(Map.of(
-            "root", fsRoot.toString(),
-            "overwrite.enabled", "false"
-        ));
-
-        final InputStream logFile = new ByteArrayInputStream("log file".getBytes());
-        osFactory.fileUploader().upload(logFile, "aaa/0.log.txt");
-
-        assertThatThrownBy(() -> osFactory.fileUploader().upload(logFile, "aaa/0.log.txt"))
-            .isInstanceOf(IOException.class)
-            .hasMessage("File %s already exists", fsRoot + "/aaa/0.log.txt");
-    }
-
-    @Test
-    void testAllowOverwriting(@TempDir final Path tempDir) throws IOException {
-        final File fsRoot = tempDir.toFile();
-        final ObjectStorageFactory osFactory = new FileSystemStorageFactory();
-        osFactory.configure(Map.of(
-            "root", fsRoot.toString(),
-            "overwrite.enabled", "true"
-        ));
-
-        final byte[] data1 = "log file 1".getBytes();
-        osFactory.fileUploader().upload(new ByteArrayInputStream(data1), "aaa/0.log.txt");
-        assertThat(Files.readAllBytes(Path.of(fsRoot.getPath(), "aaa/0.log.txt")))
-            .isEqualTo(data1);
-
-        final byte[] data2 = "log file 2".getBytes();
-        assertThatNoException().isThrownBy(
-            () -> osFactory.fileUploader().upload(new ByteArrayInputStream(data2), "aaa/0.log.txt"));
-        assertThat(Files.readAllBytes(Path.of(fsRoot.getPath(), "aaa/0.log.txt")))
-            .isEqualTo(data2);
-    }
-
     @Test
     void testUploadFetchDelete(@TempDir final Path tempDir) throws IOException {
         final File fsRoot = tempDir.toFile();

--- a/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageTest.java
+++ b/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageTest.java
@@ -42,7 +42,7 @@ class FileSystemStorageTest {
         final Path wrongRoot = root.resolve("file_instead");
         Files.writeString(wrongRoot, "Wrong root");
 
-        assertThatThrownBy(() -> new FileSystemStorage(wrongRoot, true))
+        assertThatThrownBy(() -> new FileSystemStorage(wrongRoot))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage(wrongRoot + " must be a writable directory");
     }
@@ -52,14 +52,14 @@ class FileSystemStorageTest {
         final Path nonWritableDir = root.resolve("non_writable");
         Files.createDirectory(nonWritableDir).toFile().setReadOnly();
 
-        assertThatThrownBy(() -> new FileSystemStorage(nonWritableDir, true))
+        assertThatThrownBy(() -> new FileSystemStorage(nonWritableDir))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage(nonWritableDir + " must be a writable directory");
     }
 
     @Test
     void testUploadANewFile() throws IOException {
-        final FileSystemStorage storage = new FileSystemStorage(root, false);
+        final FileSystemStorage storage = new FileSystemStorage(root);
         final String content = "content";
         storage.upload(new ByteArrayInputStream(content.getBytes()), TOPIC_PARTITION_SEGMENT_KEY);
 
@@ -67,25 +67,11 @@ class FileSystemStorageTest {
     }
 
     @Test
-    void testUploadFailsWhenFileExists() throws IOException {
-        final Path previous = root.resolve(TOPIC_PARTITION_SEGMENT_KEY);
-        Files.createDirectories(previous.getParent());
-        Files.writeString(previous, "previous");
-        final FileSystemStorage storage = new FileSystemStorage(root, false);
-        final String content = "content";
-
-        assertThatThrownBy(() ->
-            storage.upload(new ByteArrayInputStream(content.getBytes()), TOPIC_PARTITION_SEGMENT_KEY))
-            .isInstanceOf(IOException.class)
-            .hasMessage("File " + previous + " already exists");
-    }
-
-    @Test
     void testUploadWithOverridesWhenFileExists() throws IOException {
         final Path previous = root.resolve(TOPIC_PARTITION_SEGMENT_KEY);
         Files.createDirectories(previous.getParent());
         Files.writeString(previous, "previous");
-        final FileSystemStorage storage = new FileSystemStorage(root, true);
+        final FileSystemStorage storage = new FileSystemStorage(root);
         final String content = "content";
         storage.upload(new ByteArrayInputStream(content.getBytes()), TOPIC_PARTITION_SEGMENT_KEY);
         assertThat(previous).hasContent(content);
@@ -97,7 +83,7 @@ class FileSystemStorageTest {
         final Path keyPath = root.resolve(TOPIC_PARTITION_SEGMENT_KEY);
         Files.createDirectories(keyPath.getParent());
         Files.writeString(keyPath, content);
-        final FileSystemStorage storage = new FileSystemStorage(root, true);
+        final FileSystemStorage storage = new FileSystemStorage(root);
 
         try (final InputStream fetch = storage.fetch(TOPIC_PARTITION_SEGMENT_KEY)) {
             assertThat(fetch).hasContent(content);
@@ -113,7 +99,7 @@ class FileSystemStorageTest {
         final Path keyPath = root.resolve(TOPIC_PARTITION_SEGMENT_KEY);
         Files.createDirectories(keyPath.getParent());
         Files.writeString(keyPath, content);
-        final FileSystemStorage storage = new FileSystemStorage(root, true);
+        final FileSystemStorage storage = new FileSystemStorage(root);
 
         try (final InputStream fetch = storage.fetch(TOPIC_PARTITION_SEGMENT_KEY, BytesRange.of(from, to))) {
             assertThat(fetch).hasContent(range);
@@ -126,7 +112,7 @@ class FileSystemStorageTest {
         final Path keyPath = root.resolve(TOPIC_PARTITION_SEGMENT_KEY);
         Files.createDirectories(keyPath.getParent());
         Files.writeString(keyPath, content);
-        final FileSystemStorage storage = new FileSystemStorage(root, true);
+        final FileSystemStorage storage = new FileSystemStorage(root);
 
         try (final InputStream fetch = storage.fetch(TOPIC_PARTITION_SEGMENT_KEY, BytesRange.of(2, 3))) {
             assertThat(fetch).hasContent("C");
@@ -139,7 +125,7 @@ class FileSystemStorageTest {
         final Path keyPath = root.resolve(TOPIC_PARTITION_SEGMENT_KEY);
         Files.createDirectories(keyPath.getParent());
         Files.writeString(keyPath, content);
-        final FileSystemStorage storage = new FileSystemStorage(root, true);
+        final FileSystemStorage storage = new FileSystemStorage(root);
 
 
         assertThatThrownBy(() -> storage.fetch(TOPIC_PARTITION_SEGMENT_KEY, BytesRange.of(0, content.length() + 1)))
@@ -152,7 +138,7 @@ class FileSystemStorageTest {
         final Path keyPath = root.resolve(TOPIC_PARTITION_SEGMENT_KEY);
         Files.createDirectories(keyPath.getParent());
         Files.writeString(keyPath, "test");
-        final FileSystemStorage storage = new FileSystemStorage(root, false);
+        final FileSystemStorage storage = new FileSystemStorage(root);
         storage.delete(TOPIC_PARTITION_SEGMENT_KEY);
 
         assertThat(keyPath).doesNotExist(); // segment key
@@ -170,7 +156,7 @@ class FileSystemStorageTest {
         Files.writeString(parentPath.resolve("another"), "test");
         final Path keyPath = parentPath.resolve(key);
         Files.writeString(keyPath, "test");
-        final FileSystemStorage storage = new FileSystemStorage(root, false);
+        final FileSystemStorage storage = new FileSystemStorage(root);
         storage.delete(parent + "/" + key);
 
         assertThat(keyPath).doesNotExist();


### PR DESCRIPTION
File system storage backend doesn't require overwrite flag as retries from RemoteStorageManager should always overwrite segments.