### PR TITLE
feat: add storage back-end exception

### DIFF
--- a/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/ChunkManager.java
+++ b/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/ChunkManager.java
@@ -16,7 +16,6 @@
 
 package io.aiven.kafka.tieredstorage.commons;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
@@ -25,6 +24,7 @@ import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
 import io.aiven.kafka.tieredstorage.commons.manifest.SegmentManifest;
 import io.aiven.kafka.tieredstorage.commons.security.AesEncryptionProvider;
 import io.aiven.kafka.tieredstorage.commons.storage.ObjectStorageFactory;
+import io.aiven.kafka.tieredstorage.commons.storage.StorageBackEndException;
 import io.aiven.kafka.tieredstorage.commons.transform.BaseDetransformChunkEnumeration;
 import io.aiven.kafka.tieredstorage.commons.transform.DecompressionChunkEnumeration;
 import io.aiven.kafka.tieredstorage.commons.transform.DecryptionChunkEnumeration;
@@ -49,7 +49,7 @@ public class ChunkManager {
      * @return an {@link InputStream} of the chunk, plain text (i.e. decrypted and decompressed).
      */
     public InputStream getChunk(final RemoteLogSegmentMetadata remoteLogSegmentMetadata, final SegmentManifest manifest,
-            final int chunkId) throws IOException {
+            final int chunkId) throws StorageBackEndException {
         final Chunk chunk = manifest.chunkIndex().chunks().get(chunkId);
         final String segmentKey = objectKey.key(remoteLogSegmentMetadata, ObjectKey.Suffix.LOG);
         final InputStream chunkContent = objectStorageFactory.fileFetcher().fetch(segmentKey, chunk.range());

--- a/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/FileFetcher.java
+++ b/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/FileFetcher.java
@@ -16,7 +16,6 @@
 
 package io.aiven.kafka.tieredstorage.commons.storage;
 
-import java.io.IOException;
 import java.io.InputStream;
 
 public interface FileFetcher {
@@ -24,12 +23,12 @@ public interface FileFetcher {
      * Fetch file.
      * @param key file key.
      */
-    InputStream fetch(String key) throws IOException;
+    InputStream fetch(String key) throws StorageBackEndException;
 
     /**
      * Fetch file.
      * @param key file key.
      * @param range start (inclusive)/end (exclusive) position
      */
-    InputStream fetch(String key, BytesRange range) throws IOException;
+    InputStream fetch(String key, BytesRange range) throws StorageBackEndException;
 }

--- a/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/FileUploader.java
+++ b/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/FileUploader.java
@@ -16,9 +16,8 @@
 
 package io.aiven.kafka.tieredstorage.commons.storage;
 
-import java.io.IOException;
 import java.io.InputStream;
 
 public interface FileUploader {
-    void upload(InputStream inputStream, String key) throws IOException;
+    void upload(InputStream inputStream, String key) throws StorageBackEndException;
 }

--- a/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/StorageBackEndException.java
+++ b/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/StorageBackEndException.java
@@ -16,6 +16,13 @@
 
 package io.aiven.kafka.tieredstorage.commons.storage;
 
-public interface FileDeleter {
-    void delete(String key) throws StorageBackEndException;
+public class StorageBackEndException extends Exception {
+
+    public StorageBackEndException(final String message) {
+        super(message);
+    }
+
+    public StorageBackEndException(final String message, final Throwable e) {
+        super(message, e);
+    }
 }

--- a/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/transform/FetchChunkEnumeration.java
+++ b/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/transform/FetchChunkEnumeration.java
@@ -29,6 +29,7 @@ import io.aiven.kafka.tieredstorage.commons.Chunk;
 import io.aiven.kafka.tieredstorage.commons.ChunkManager;
 import io.aiven.kafka.tieredstorage.commons.manifest.SegmentManifest;
 import io.aiven.kafka.tieredstorage.commons.manifest.index.ChunkIndex;
+import io.aiven.kafka.tieredstorage.commons.storage.StorageBackEndException;
 
 import org.apache.commons.io.input.BoundedInputStream;
 
@@ -140,7 +141,7 @@ public class FetchChunkEnumeration implements Enumeration<InputStream> {
     private InputStream getChunkContent(final int chunkId) {
         try {
             return chunkManager.getChunk(remoteLogSegmentMetadata, manifest, chunkId);
-        } catch (final IOException e) {
+        } catch (final StorageBackEndException e) {
             throw new RuntimeException(e);
         }
     }

--- a/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageFactoryTest.java
+++ b/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageFactoryTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import io.aiven.kafka.tieredstorage.commons.storage.BytesRange;
 import io.aiven.kafka.tieredstorage.commons.storage.ObjectStorageFactory;
+import io.aiven.kafka.tieredstorage.commons.storage.StorageBackEndException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -33,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class FileSystemStorageFactoryTest {
     @Test
-    void testUploadFetchDelete(@TempDir final Path tempDir) throws IOException {
+    void testUploadFetchDelete(@TempDir final Path tempDir) throws IOException, StorageBackEndException {
         final File fsRoot = tempDir.toFile();
         final ObjectStorageFactory osFactory = new FileSystemStorageFactory();
         osFactory.configure(Map.of(

--- a/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageTest.java
+++ b/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import io.aiven.kafka.tieredstorage.commons.storage.BytesRange;
+import io.aiven.kafka.tieredstorage.commons.storage.StorageBackEndException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -58,7 +59,7 @@ class FileSystemStorageTest {
     }
 
     @Test
-    void testUploadANewFile() throws IOException {
+    void testUploadANewFile() throws StorageBackEndException {
         final FileSystemStorage storage = new FileSystemStorage(root);
         final String content = "content";
         storage.upload(new ByteArrayInputStream(content.getBytes()), TOPIC_PARTITION_SEGMENT_KEY);
@@ -67,7 +68,7 @@ class FileSystemStorageTest {
     }
 
     @Test
-    void testUploadWithOverridesWhenFileExists() throws IOException {
+    void testUploadWithOverridesWhenFileExists() throws IOException, StorageBackEndException {
         final Path previous = root.resolve(TOPIC_PARTITION_SEGMENT_KEY);
         Files.createDirectories(previous.getParent());
         Files.writeString(previous, "previous");
@@ -78,7 +79,7 @@ class FileSystemStorageTest {
     }
 
     @Test
-    void testFetchAll() throws IOException {
+    void testFetchAll() throws IOException, StorageBackEndException {
         final String content = "content";
         final Path keyPath = root.resolve(TOPIC_PARTITION_SEGMENT_KEY);
         Files.createDirectories(keyPath.getParent());
@@ -91,7 +92,7 @@ class FileSystemStorageTest {
     }
 
     @Test
-    void testFetchWithOffsetRange() throws IOException {
+    void testFetchWithOffsetRange() throws IOException, StorageBackEndException {
         final String content = "AABBBBAA";
         final int from = 2;
         final int to = 6;
@@ -107,7 +108,7 @@ class FileSystemStorageTest {
     }
 
     @Test
-    void testFetchSingleByte() throws IOException {
+    void testFetchSingleByte() throws IOException, StorageBackEndException {
         final String content = "ABC";
         final Path keyPath = root.resolve(TOPIC_PARTITION_SEGMENT_KEY);
         Files.createDirectories(keyPath.getParent());
@@ -134,7 +135,7 @@ class FileSystemStorageTest {
     }
 
     @Test
-    void testDelete() throws IOException {
+    void testDelete() throws IOException, StorageBackEndException {
         final Path keyPath = root.resolve(TOPIC_PARTITION_SEGMENT_KEY);
         Files.createDirectories(keyPath.getParent());
         Files.writeString(keyPath, "test");
@@ -148,7 +149,7 @@ class FileSystemStorageTest {
     }
 
     @Test
-    void testDeleteDoesNotRemoveParentDir() throws IOException {
+    void testDeleteDoesNotRemoveParentDir() throws IOException, StorageBackEndException {
         final String parent = "parent";
         final String key = "key";
         final Path parentPath = root.resolve(parent);

--- a/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/transform/FetchChunkEnumerationTest.java
+++ b/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/transform/FetchChunkEnumerationTest.java
@@ -17,7 +17,6 @@
 package io.aiven.kafka.tieredstorage.commons.transform;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.util.NoSuchElementException;
 
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
@@ -26,6 +25,7 @@ import io.aiven.kafka.tieredstorage.commons.ChunkManager;
 import io.aiven.kafka.tieredstorage.commons.manifest.SegmentManifest;
 import io.aiven.kafka.tieredstorage.commons.manifest.SegmentManifestV1;
 import io.aiven.kafka.tieredstorage.commons.manifest.index.FixedSizeChunkIndex;
+import io.aiven.kafka.tieredstorage.commons.storage.StorageBackEndException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -94,7 +94,7 @@ class FetchChunkEnumerationTest {
 
     // - Single chunk
     @Test
-    void shouldReturnRangeFromSingleChunk() throws IOException {
+    void shouldReturnRangeFromSingleChunk() throws StorageBackEndException {
         // Given a set of 10 chunks with 10 bytes each
         // When
         final int from = 32;
@@ -112,7 +112,7 @@ class FetchChunkEnumerationTest {
 
     // - Multiple chunks
     @Test
-    void shouldReturnRangeFromMultipleChunks() throws IOException {
+    void shouldReturnRangeFromMultipleChunks() throws StorageBackEndException {
         // Given a set of 10 chunks with 10 bytes each
         // When
         final int from = 15;


### PR DESCRIPTION
Different storage back-ends will return different exceptions when reading/writing.
At the moment, storage layer has interfaces with IOException defined. This PR is proposing to have a checked exception for the whole storage layer. We can create sub-types for more specific exceptions (e.g. #208)
