### PR TITLE
refactor: align file-system storage with s3 

### DIFF
--- a/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/BytesRange.java
+++ b/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/BytesRange.java
@@ -18,7 +18,6 @@ package io.aiven.kafka.tieredstorage.commons.storage;
 
 /**
  * Byte range with from and to edges; where to cannot be less than from.
- * inclusive/exclusive semantics are up to the consumer.
  */
 public class BytesRange {
     public final int from;

--- a/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/InvalidRangeException.java
+++ b/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/InvalidRangeException.java
@@ -16,19 +16,8 @@
 
 package io.aiven.kafka.tieredstorage.commons.storage;
 
-import java.io.InputStream;
-
-public interface FileFetcher {
-    /**
-     * Fetch file.
-     * @param key file key.
-     */
-    InputStream fetch(String key) throws StorageBackEndException;
-
-    /**
-     * Fetch file.
-     * @param key file key.
-     * @param range range with inclusive start/end positions
-     */
-    InputStream fetch(String key, BytesRange range) throws StorageBackEndException;
+public class InvalidRangeException extends StorageBackEndException {
+    public InvalidRangeException(final String message) {
+        super(message);
+    }
 }

--- a/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/UniversalRemoteStorageManagerTest.java
+++ b/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/UniversalRemoteStorageManagerTest.java
@@ -340,10 +340,22 @@ class UniversalRemoteStorageManagerTest extends RsaKeyAwareTest {
 
         final int actualChunkSize = (int) Math.min(chunkSize, Files.size(logFilePath) - 2);
         // TODO more combinations?
-        for (final int readSize : List.of(1, 13, actualChunkSize / 2, actualChunkSize, actualChunkSize + 1,
-            actualChunkSize * 2)) {
+        for (final int readSize : List.of(
+            1,
+            13,
+            actualChunkSize / 2,
+            actualChunkSize,
+            actualChunkSize + 1,
+            actualChunkSize * 2
+        )) {
             final byte[] expectedBytes = new byte[readSize];
-            for (final int offset : List.of(0, 1, 23, actualChunkSize / 2, actualChunkSize - 1, actualChunkSize,
+            for (final int offset : List.of(
+                0,
+                1,
+                23,
+                actualChunkSize / 2,
+                actualChunkSize - 1,
+                actualChunkSize,
                 actualChunkSize + 1
             )) {
                 final int read;
@@ -351,7 +363,8 @@ class UniversalRemoteStorageManagerTest extends RsaKeyAwareTest {
                     r.seek(offset);
                     read = r.read(expectedBytes, 0, readSize);
                 }
-                try (InputStream actual = rsm.fetchLogSegment(REMOTE_LOG_METADATA, offset, offset + readSize)) {
+                final int inclusiveEndPosition = offset + readSize - 1;
+                try (InputStream actual = rsm.fetchLogSegment(REMOTE_LOG_METADATA, offset, inclusiveEndPosition)) {
                     assertThat(actual.readAllBytes())
                         .isEqualTo(Arrays.copyOfRange(expectedBytes, 0, read));
                 }

--- a/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageTest.java
+++ b/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/storage/filesystem/FileSystemStorageTest.java
@@ -21,7 +21,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import io.aiven.kafka.tieredstorage.commons.storage.BaseStorageTest;
-import io.aiven.kafka.tieredstorage.commons.storage.BytesRange;
 import io.aiven.kafka.tieredstorage.commons.storage.FileDeleter;
 import io.aiven.kafka.tieredstorage.commons.storage.FileFetcher;
 import io.aiven.kafka.tieredstorage.commons.storage.FileUploader;
@@ -71,19 +70,6 @@ class FileSystemStorageTest extends BaseStorageTest {
         assertThatThrownBy(() -> new FileSystemStorage(nonWritableDir))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage(nonWritableDir + " must be a writable directory");
-    }
-
-    @Test
-    void testFetchWithOffsetRangeLargerThanFileSize() throws IOException {
-        final String content = "content";
-        final Path keyPath = root.resolve(TOPIC_PARTITION_SEGMENT_KEY);
-        Files.createDirectories(keyPath.getParent());
-        Files.writeString(keyPath, content);
-        final FileSystemStorage storage = new FileSystemStorage(root);
-
-        assertThatThrownBy(() -> storage.fetch(TOPIC_PARTITION_SEGMENT_KEY, BytesRange.of(0, content.length() + 1)))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("position 'to' cannot be higher than the file size, to=8, file size=7 given");
     }
 
     @Test

--- a/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/transform/FetchChunkEnumerationTest.java
+++ b/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/transform/FetchChunkEnumerationTest.java
@@ -25,6 +25,7 @@ import io.aiven.kafka.tieredstorage.commons.ChunkManager;
 import io.aiven.kafka.tieredstorage.commons.manifest.SegmentManifest;
 import io.aiven.kafka.tieredstorage.commons.manifest.SegmentManifestV1;
 import io.aiven.kafka.tieredstorage.commons.manifest.index.FixedSizeChunkIndex;
+import io.aiven.kafka.tieredstorage.commons.storage.BytesRange;
 import io.aiven.kafka.tieredstorage.commons.storage.StorageBackEndException;
 
 import org.junit.jupiter.api.Test;
@@ -60,7 +61,7 @@ class FetchChunkEnumerationTest {
         final int to = from + 1;
         // Then
         assertThatThrownBy(
-            () -> new FetchChunkEnumeration(chunkManager, remoteLogSegmentMetadata, manifest, from, to))
+            () -> new FetchChunkEnumeration(chunkManager, remoteLogSegmentMetadata, manifest, BytesRange.of(from, to)))
             .hasMessage("Invalid start position " + from + " in segment remoteLogSegmentMetadata");
     }
 
@@ -73,7 +74,7 @@ class FetchChunkEnumerationTest {
         final int to = 80;
         // Then
         final FetchChunkEnumeration fetchChunk =
-            new FetchChunkEnumeration(chunkManager, remoteLogSegmentMetadata, manifest, from, to);
+            new FetchChunkEnumeration(chunkManager, remoteLogSegmentMetadata, manifest, BytesRange.of(from, to));
         assertThat(fetchChunk.startChunkId).isEqualTo(0);
         assertThat(fetchChunk.lastChunkId).isEqualTo(8);
     }
@@ -86,7 +87,7 @@ class FetchChunkEnumerationTest {
         final int from = 0;
         final int to = 110;
         final FetchChunkEnumeration fetchChunk =
-            new FetchChunkEnumeration(chunkManager, remoteLogSegmentMetadata, manifest, from, to);
+            new FetchChunkEnumeration(chunkManager, remoteLogSegmentMetadata, manifest, BytesRange.of(from, to));
         // Then
         assertThat(fetchChunk.startChunkId).isEqualTo(0);
         assertThat(fetchChunk.lastChunkId).isEqualTo(9);
@@ -98,9 +99,9 @@ class FetchChunkEnumerationTest {
         // Given a set of 10 chunks with 10 bytes each
         // When
         final int from = 32;
-        final int to = 35;
+        final int to = 34;
         final FetchChunkEnumeration fetchChunk =
-            new FetchChunkEnumeration(chunkManager, remoteLogSegmentMetadata, manifest, from, to);
+            new FetchChunkEnumeration(chunkManager, remoteLogSegmentMetadata, manifest, BytesRange.of(from, to));
         when(chunkManager.getChunk(remoteLogSegmentMetadata, manifest, fetchChunk.currentChunkId))
             .thenReturn(new ByteArrayInputStream(CHUNK_CONTENT));
         // Then
@@ -116,9 +117,9 @@ class FetchChunkEnumerationTest {
         // Given a set of 10 chunks with 10 bytes each
         // When
         final int from = 15;
-        final int to = 35;
+        final int to = 34;
         final FetchChunkEnumeration fetchChunk =
-            new FetchChunkEnumeration(chunkManager, remoteLogSegmentMetadata, manifest, from, to);
+            new FetchChunkEnumeration(chunkManager, remoteLogSegmentMetadata, manifest, BytesRange.of(from, to));
         when(chunkManager.getChunk(remoteLogSegmentMetadata, manifest, 1))
             .thenReturn(new ByteArrayInputStream(CHUNK_CONTENT));
         when(chunkManager.getChunk(remoteLogSegmentMetadata, manifest, 2))


### PR DESCRIPTION
Couple of changes to align file-system storage with S3 and other back-ends:

- Do not throw exception when range end is larger than file size, but when range start is (introduce an "InvalidRangeException").
- Use range as inclusive start and end. Kafka TS fetch range is inclusive and S3 GET range is also inclusive.  
 
Depends on #215  