### PR TITLE
feat: apply compression heuristic

### DIFF
--- a/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/UniversalRemoteStorageManager.java
+++ b/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/UniversalRemoteStorageManager.java
@@ -20,6 +20,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
@@ -81,11 +82,10 @@ public class UniversalRemoteStorageManager implements RemoteStorageManager {
 
     private final Executor executor = new ForkJoinPool();
 
-    private UniversalRemoteStorageManagerConfig config;
-
     private ObjectStorageFactory objectStorageFactory;
-    private boolean compression;
-    private boolean encryption;
+    private boolean compressionEnabled;
+    private boolean compressionHeuristic;
+    private boolean encryptionEnabled;
     private int chunkSize;
     private RsaEncryptionProvider rsaEncryptionProvider;
     private AesEncryptionProvider aesEncryptionProvider;
@@ -114,11 +114,11 @@ public class UniversalRemoteStorageManager implements RemoteStorageManager {
     @Override
     public void configure(final Map<String, ?> configs) {
         Objects.requireNonNull(configs, "configs must not be null");
-        config = new UniversalRemoteStorageManagerConfig(configs);
+        final UniversalRemoteStorageManagerConfig config = new UniversalRemoteStorageManagerConfig(configs);
         objectStorageFactory = config.objectStorageFactory();
         objectKey = new ObjectKey(config.keyPrefix());
-        encryption = config.encryptionEnabled();
-        if (encryption) {
+        encryptionEnabled = config.encryptionEnabled();
+        if (encryptionEnabled) {
             rsaEncryptionProvider = RsaEncryptionProvider.of(
                 config.encryptionPublicKeyFile(),
                 config.encryptionPrivateKeyFile()
@@ -133,7 +133,8 @@ public class UniversalRemoteStorageManager implements RemoteStorageManager {
         );
 
         chunkSize = config.chunkSize();
-        compression = config.compressionEnabled();
+        compressionEnabled = config.compressionEnabled();
+        compressionHeuristic = config.compressionHeuristicEnabled();
 
         mapper = getObjectMapper();
 
@@ -149,7 +150,7 @@ public class UniversalRemoteStorageManager implements RemoteStorageManager {
     private ObjectMapper getObjectMapper() {
         final ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new Jdk8Module());
-        if (encryption) {
+        if (encryptionEnabled) {
             final SimpleModule simpleModule = new SimpleModule();
             simpleModule.addSerializer(SecretKey.class, new DataKeySerializer(rsaEncryptionProvider::encryptDataKey));
             simpleModule.addDeserializer(SecretKey.class, new DataKeyDeserializer(
@@ -171,30 +172,25 @@ public class UniversalRemoteStorageManager implements RemoteStorageManager {
             TransformChunkEnumeration transformEnum = new BaseTransformChunkEnumeration(
                 Files.newInputStream(logSegmentData.logSegment()), chunkSize);
             SegmentEncryptionMetadataV1 encryptionMetadata = null;
-            if (compression) {
+            final boolean requiresCompression = requiresCompression(logSegmentData);
+            if (requiresCompression) {
                 transformEnum = new CompressionChunkEnumeration(transformEnum);
             }
-            if (encryption) {
+            if (encryptionEnabled) {
                 final DataKeyAndAAD dataKeyAndAAD = aesEncryptionProvider.createDataKeyAndAAD();
                 transformEnum = new EncryptionChunkEnumeration(
                     transformEnum,
                     () -> aesEncryptionProvider.encryptionCipher(dataKeyAndAAD));
                 encryptionMetadata = new SegmentEncryptionMetadataV1(dataKeyAndAAD.dataKey, dataKeyAndAAD.aad);
             }
-            final var transformFinisher =
+            final TransformFinisher transformFinisher =
                 new TransformFinisher(transformEnum, remoteLogSegmentMetadata.segmentSizeInBytes());
-            try (final var sis = new SequenceInputStream(transformFinisher)) {
-                final String fileKey =
-                    objectKey.key(remoteLogSegmentMetadata, ObjectKey.Suffix.LOG);
-                objectStorageFactory.fileUploader().upload(sis, fileKey);
-            }
-
+            uploadSegmentLog(remoteLogSegmentMetadata, transformFinisher);
 
             final ChunkIndex chunkIndex = transformFinisher.chunkIndex();
             final SegmentManifest segmentManifest =
-                new SegmentManifestV1(chunkIndex, compression, encryptionMetadata);
+                new SegmentManifestV1(chunkIndex, requiresCompression, encryptionMetadata);
             uploadManifest(remoteLogSegmentMetadata, segmentManifest);
-
 
             uploadIndexFile(remoteLogSegmentMetadata, Files.newInputStream(logSegmentData.offsetIndex()), OFFSET);
             uploadIndexFile(remoteLogSegmentMetadata, Files.newInputStream(logSegmentData.timeIndex()),
@@ -209,6 +205,34 @@ public class UniversalRemoteStorageManager implements RemoteStorageManager {
                 LEADER_EPOCH);
         } catch (final StorageBackEndException | IOException e) {
             throw new RemoteStorageException(e);
+        }
+    }
+
+    boolean requiresCompression(final LogSegmentData logSegmentData) {
+        boolean requiresCompression = false;
+        if (compressionEnabled) {
+            if (compressionHeuristic) {
+                try {
+                    final File segmentFile = logSegmentData.logSegment().toFile();
+                    final boolean alreadyCompressed = SegmentCompressionChecker.check(segmentFile);
+                    requiresCompression = !alreadyCompressed;
+                } catch (final InvalidRecordBatchException e) {
+                    // Log and leave value as false to upload uncompressed.
+                    log.warn("Failed to check compression on log segment: {}", logSegmentData.logSegment(), e);
+                }
+            } else {
+                requiresCompression = true;
+            }
+        }
+        return requiresCompression;
+    }
+
+    private void uploadSegmentLog(final RemoteLogSegmentMetadata remoteLogSegmentMetadata,
+                                  final TransformFinisher transformFinisher)
+        throws IOException, StorageBackEndException {
+        final String fileKey = objectKey.key(remoteLogSegmentMetadata, ObjectKey.Suffix.LOG);
+        try (final var sis = new SequenceInputStream(transformFinisher)) {
+            objectStorageFactory.fileUploader().upload(sis, fileKey);
         }
     }
 

--- a/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/SegmentCompressionCheckerTest.java
+++ b/commons/src/test/java/io/aiven/kafka/tieredstorage/commons/SegmentCompressionCheckerTest.java
@@ -83,7 +83,7 @@ class SegmentCompressionCheckerTest {
     @CsvSource({"NONE,false", "ZSTD,true"})
     void shouldReturnCompressedWhenEnabled(final CompressionType compressionType, final boolean result)
         throws InvalidRecordBatchException, IOException {
-        final File file = Files.newFile(dir.resolve("segment.log").toString());
+        final File file = dir.resolve("segment.log").toFile();
         try (final FileRecords records = FileRecords.open(file, false, 100000, true);
              final MemoryRecordsBuilder builder = MemoryRecords.builder(
                  ByteBuffer.allocate(1024),
@@ -104,7 +104,7 @@ class SegmentCompressionCheckerTest {
                                                       final CompressionType nextCompressionType,
                                                       final boolean result)
         throws InvalidRecordBatchException, IOException {
-        final File file = Files.newFile(dir.resolve("segment.log").toString());
+        final File file = dir.resolve("segment.log").toFile();
         try (final FileRecords records = FileRecords.open(file, false, 100000, true);
              final MemoryRecordsBuilder b1 = MemoryRecords.builder(
                  ByteBuffer.allocate(1024),


### PR DESCRIPTION
Use segment compression checker to validate at runtime when a segment requires compression when heuristic flag is enabled (disabled by default).