### PR TITLE
fix: make URSM default constructor public

### DIFF
--- a/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/UniversalRemoteStorageManager.java
+++ b/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/UniversalRemoteStorageManager.java
@@ -95,7 +95,7 @@ public class UniversalRemoteStorageManager implements RemoteStorageManager {
 
     private SegmentManifestProvider segmentManifestProvider;
 
-    UniversalRemoteStorageManager() {
+    public UniversalRemoteStorageManager() {
         this(Time.SYSTEM);
     }
 


### PR DESCRIPTION
When instantiated from Tiered Storage framework on the broker side, default constructor needs to be public, else fails with:

```
Caused by: java.lang.IllegalAccessException: class kafka.log.remote.RemoteLogManager$$anon$2 cannot access a member of class io.aiven.kafka.tieredstorage.commons.UniversalRemoteStorageManager with modifiers ""
```