### PR TITLE
Adding toString method to BytesRange

### DIFF
--- a/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/BytesRange.java
+++ b/commons/src/main/java/io/aiven/kafka/tieredstorage/commons/storage/BytesRange.java
@@ -53,6 +53,14 @@ public class BytesRange {
         return result;
     }
 
+    @Override
+    public String toString() {
+        return "BytesRange("
+            + "from=" + from
+            + ", to=" + to
+            + ")";
+    }
+
     public static BytesRange of(final int from, final int to) {
         return new BytesRange(from, to);
     }


### PR DESCRIPTION
Since BytesRange is used in log/exception messages it should have a proper `.toString` method