### PR TITLE
chore: update Docker to new implementation

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -13,8 +13,8 @@ retention=1000000000 # 1G
 local_retention=300000000 # 300M
 
 kafka-topic:
-	${KAFKA_HOME}/bin/kafka-topics.sh \
-		--bootstrap-server localhost:9092 \
+	docker exec kafka kafka-topics.sh \
+		--bootstrap-server kafka:29092 \
 		--create \
 		--config remote.storage.enable=true \
 		--config segment.bytes=$(segment) \

--- a/docker/README.md
+++ b/docker/README.md
@@ -15,14 +15,6 @@ Docker compose environment to try out tiered storage plugins.
 
 Build plugin before starting Docker compose:
 
-#### Build plugin libraries
-
-On root directory:
-
-```shell
-./gradlew clean installDist
-```
-
 #### Using Encryption mechanisms
 
 Generate RSA key pair:
@@ -45,9 +37,9 @@ and set paths on `compose.yml` file:
       - config/server.properties
       # ...
       - --override
-      - rsm.config.s3.public_key_pem=/kafka/plugins/public.pem
+      - rsm.config.encryption.public.key.file=/kafka/plugins/public.pem
       - --override
-      - rsm.config.s3.private_key_pem=/kafka/plugins/private.pem
+      - rsm.config.encryption.private.key.file=/kafka/plugins/private.pem
       # ...
 ```
 
@@ -56,16 +48,7 @@ and set paths on `compose.yml` file:
 > for AWS S3 try [./s3](./s3) directory and
 > for Minio S3 try [./s3-minio](./s3-minio) directory
 
-`compose.yml` is mounting the distribution directory:
-
-```yaml
-kafka:
-  # ...
-  volumes:
-    - ./../../s3/build/install/s3:/kafka/plugins/tiered-storage-s3
-```
-
-and then:
+Start docker compose (will build image if needed):
 
 ```shell
 docker-compose up -d
@@ -85,20 +68,15 @@ and use variables on `compose.yml`:
 ```yaml
   kafka:
     # ...
-    volumes:
-      # ...
-      - ./private.pem:/kafka/plugins/private.pem
-      - ./public.pem:/kafka/plugins/public.pem
     command:
       - kafka-server-start.sh
       - config/server.properties
       # ...
       - --override
-      - rsm.config.s3.client.aws_access_key_id=${AWS_ACCESS_KEY_ID}
+      - rsm.config.storage.aws.access.key.id=${AWS_ACCESS_KEY_ID}
       - --override
-      - rsm.config.s3.client.aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+      - rsm.config.storage.aws.secret.access.key=${AWS_SECRET_ACCESS_KEY}
 ```
-
 
 ### Kafka
 
@@ -108,6 +86,5 @@ Creating topics with Tiered storage:
 make kafka-topic
 ```
 
-creates a topic t1 with 6 partitions, 10MB segments, retention bytes 100MB, and 20MB local retention.
-
-
+creates a topic t1 with 6 partitions, 10MB segments, retention bytes 100MB, and 20MB local retention,
+and start writing messages to test retention and shipping logs to tiered-storage.

--- a/docker/kafka/Dockerfile
+++ b/docker/kafka/Dockerfile
@@ -1,38 +1,53 @@
+FROM eclipse-temurin:17 AS plugin
+
+ENV PLUGIN_VERSION 0.0.1-SNAPSHOT
+
+COPY . /kafka-ts-plugin
+
+# Build TS plugin
+WORKDIR /kafka-ts-plugin
+RUN ./gradlew releaseTarGz
+
+# Unpack release distribution
+WORKDIR /kafka-ts-plugin/build/distributions
+RUN tar -xf tiered-storage-for-apache-kafka-${PLUGIN_VERSION}.tgz
+
 FROM fedora:37 AS base
 
-ENV JAVA_VERSION 11
+ENV JAVA_VERSION 17
 RUN dnf install -y java-${JAVA_VERSION}-openjdk-devel git
 
 ENV JAVA_HOME /usr/lib/jvm/java-${JAVA_VERSION}-openjdk
 # Working with a fully functional TS branch by default
 # - upstream doesn't have a fully working TS
 #   - https://github.com/apache/kafka/pull/13535
-# - aiven's 3.3 has issue with fetching
-#   - https://github.com/aiven/kafka/issues/15
 ARG AK_REPO=https://github.com/aiven/kafka
-ARG AK_BRANCH=3.0-2022-03-31-tiered-storage
-ARG KAFKA_VERSION=3.0.1-SNAPSHOT
+ARG AK_BRANCH=3.3-2022-10-06-tiered-storage
+ARG KAFKA_VERSION=3.3.2-SNAPSHOT
 
 RUN git clone ${AK_REPO}
 WORKDIR /kafka
 RUN git checkout ${AK_BRANCH}
 
-ARG SCALA_VERSION=2.12
+ARG SCALA_VERSION=2.13
 
 RUN ./gradlew -PscalaVersion=${SCALA_VERSION} testJar releaseTarGz
 WORKDIR /kafka/core/build/distributions
 RUN tar xf kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz;
 
-FROM eclipse-temurin:11-jre AS kafka
+FROM eclipse-temurin:17-jre AS kafka
 
-ARG SCALA_VERSION=2.12
-ARG KAFKA_VERSION=3.0.1-SNAPSHOT
+ARG KAFKA_VERSION=3.3.2-SNAPSHOT
+ARG SCALA_VERSION=2.13
+ENV PLUGIN_VERSION 0.0.1-SNAPSHOT
 
 COPY --from=base /kafka/core/build/distributions/kafka_${SCALA_VERSION}-${KAFKA_VERSION} /kafka
 # Adding test jars with local implementations
 COPY --from=base /kafka/clients/build/libs/kafka-clients-${KAFKA_VERSION}-test.jar /kafka/libs/
 COPY --from=base /kafka/storage/build/libs/kafka-storage-${KAFKA_VERSION}-test.jar /kafka/libs/
 COPY --from=base /kafka/storage/api/build/libs/kafka-storage-api-${KAFKA_VERSION}-test.jar /kafka/libs/
+
+COPY --from=plugin /kafka-ts-plugin/build/distributions/tiered-storage-for-apache-kafka-${PLUGIN_VERSION} /kafka-ts-plugin
 
 ENV KAFKA_HOME /kafka
 WORKDIR ${KAFKA_HOME}

--- a/docker/s3-minio/compose.yml
+++ b/docker/s3-minio/compose.yml
@@ -8,18 +8,13 @@ services:
 
   kafka:
     image: kafka-ts-s3-minio
+    container_name: kafka
     build:
-      context: ../kafka/.
-      # Override branch used to build docker image
-      # args:
-      #   - AK_REPO=https://github.com/aiven/kafka
-      #   - AK_BRANCH=3.0-2022-03-31-tiered-storage
-      #   - KAFKA_VERSION=3.0.1-SNAPSHOT
+      context: ../../.
+      dockerfile: ./docker/kafka/Dockerfile
     ports:
       - "9092:9092"
     volumes:
-      # mount plugin
-      - ./../../s3/build/install/s3:/kafka/plugins/tiered-storage-s3
       # encryption keys
       - ./../private.pem:/kafka/plugins/private.pem
       - ./../public.pem:/kafka/plugins/public.pem
@@ -48,32 +43,29 @@ services:
       - rlmm.config.remote.log.metadata.topic.replication.factor=1
       # Tiered storage S3 plugin
       - --override
-      - remote.log.storage.manager.class.name=io.aiven.kafka.tiered.storage.s3.S3RemoteStorageManager
+      - remote.log.storage.manager.class.name=io.aiven.kafka.tieredstorage.RemoteStorageManager
       - --override
-      - remote.log.storage.manager.class.path=/kafka/plugins/tiered-storage-s3/*
+      - remote.log.storage.manager.class.path=/kafka-ts-plugin/*
       - --override
-      - rsm.config.s3.bucket.name=kafka-ts-us-east-1
+      - rsm.config.storage.backend.class.name=io.aiven.kafka.tieredstorage.storage.s3.S3Storage
       - --override
-      - rsm.config.s3.region=us-east-1
+      - rsm.config.chunk.size=10485760
       - --override
-      - rsm.config.s3.endpoint.url=http://minio:9000
+      - rsm.config.storage.s3.bucket.name=kafka-ts
       - --override
-      - rsm.config.s3.credentials.provider.class=com.amazonaws.auth.AWSStaticCredentialsProvider
+      - rsm.config.storage.s3.region=us-east-1
       - --override
-      - rsm.config.s3.client.aws_access_key_id=admin
+      - rsm.config.storage.s3.endpoint.url=http://minio:9000
       - --override
-      - rsm.config.s3.client.aws_secret_access_key=password
+      - rsm.config.storage.aws.access.key.id=admin
       - --override
-      - rsm.config.s3.public_key_pem=/kafka/plugins/public.pem
-      - --override
-      - rsm.config.s3.private_key_pem=/kafka/plugins/private.pem
+      - rsm.config.storage.aws.secret.access.key=password
 
   minio:
     image: quay.io/minio/minio
     environment:
       - MINIO_ROOT_USER=admin
       - MINIO_ROOT_PASSWORD=password
-      - MINIO_DOMAIN=minio
     ports:
       - "9000:9000"
       - "9090:9090"

--- a/docker/s3/compose.yml
+++ b/docker/s3/compose.yml
@@ -8,18 +8,13 @@ services:
 
   kafka:
     image: kafka-ts-s3-aws
+    container_name: kafka
     build:
-      context: ../kafka/.
-      # Override branch used to build docker image
-      # args:
-      #   - AK_REPO=https://github.com/aiven/kafka
-      #   - AK_BRANCH=3.0-2022-03-31-tiered-storage
-      #   - KAFKA_VERSION=3.0.1-SNAPSHOT
+      context: ../../.
+      dockerfile: ./docker/kafka/Dockerfile
     ports:
       - "9092:9092"
     volumes:
-      # mount plugin
-      - ./../../s3/build/install/s3:/kafka/plugins/tiered-storage-s3
       # encryption keys
       - ./../private.pem:/kafka/plugins/private.pem
       - ./../public.pem:/kafka/plugins/public.pem
@@ -48,20 +43,18 @@ services:
       - rlmm.config.remote.log.metadata.topic.replication.factor=1
       # Tiered storage S3 plugin
       - --override
-      - remote.log.storage.manager.class.name=io.aiven.kafka.tiered.storage.s3.S3RemoteStorageManager
+      - remote.log.storage.manager.class.name=io.aiven.kafka.tieredstorage.RemoteStorageManager
       - --override
-      - remote.log.storage.manager.class.path=/kafka/plugins/tiered-storage-s3/*
+      - remote.log.storage.manager.class.path=/kafka-ts-plugin/*
       - --override
-      - rsm.config.s3.bucket.name=kafka-ts-us-east-1
+      - rsm.config.storage.backend.class.name=io.aiven.kafka.tieredstorage.storage.s3.S3Storage
       - --override
-      - rsm.config.s3.region=us-east-1
+      - rsm.config.chunk.size=10485760
       - --override
-      - rsm.config.s3.credentials.provider.class=com.amazonaws.auth.AWSStaticCredentialsProvider
+      - rsm.config.storage.s3.bucket.name=kafka-ts
       - --override
-      - rsm.config.s3.client.aws_access_key_id=${AWS_ACCESS_KEY_ID}
+      - rsm.config.storage.s3.region=us-east-1
       - --override
-      - rsm.config.s3.client.aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
+      - rsm.config.storage.aws.access.key.id=${AWS_ACCESS_KEY_ID}
       - --override
-      - rsm.config.s3.public_key_pem=/kafka/plugins/public.pem
-      - --override
-      - rsm.config.s3.private_key_pem=/kafka/plugins/private.pem
+      - rsm.config.storage.aws.secret.access.key=${AWS_SECRET_ACCESS_KEY}

--- a/docker/test/.gitignore
+++ b/docker/test/.gitignore
@@ -1,2 +1,0 @@
-# Backend volumes
-data/

--- a/docker/test/compose.yml
+++ b/docker/test/compose.yml
@@ -8,13 +8,10 @@ services:
 
   kafka:
     image: kafka-ts-test
+    container_name: kafka
     build:
-      context: ../kafka/.
-      # Override branch used to build docker image
-      # args:
-      #   - AK_REPO=https://github.com/aiven/kafka
-      #   - AK_BRANCH=3.0-2022-03-31-tiered-storage
-      #   - KAFKA_VERSION=3.0.1-SNAPSHOT
+      context: ../../.
+      dockerfile: ./docker/kafka/Dockerfile
     ports:
       - "9092:9092"
     environment:
@@ -39,16 +36,16 @@ services:
       - remote.log.storage.system.enable=true
       # Tiered Storage: RLMM config
       - --override
-      - remote.log.storage.manager.class.name=org.apache.kafka.server.log.remote.storage.LocalTieredStorage
-      - --override
-      - remote.log.storage.manager.class.path=
-      - --override
       - remote.log.metadata.manager.class.name=org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManager
       - --override
       - rlmm.config.remote.log.metadata.common.client.bootstrap.servers=kafka:29092
       - --override
       - rlmm.config.remote.log.metadata.topic.replication.factor=1
       # Tiered storage S3 plugin
+      - --override
+      - remote.log.storage.manager.class.name=org.apache.kafka.server.log.remote.storage.LocalTieredStorage
+      - --override
+      - remote.log.storage.manager.class.path=
       - --override
       # dir at /kafka/kafka-tiered-storage/data
       - rsm.config.dir=/data


### PR DESCRIPTION
Updates Docker scripts to use latest implementation.

Changes:

- Update tiered-storage branch to 3.3
- Update JDK to 17 and Scala to 2.13
- Use docker kafka itself to create topics

