### PR TITLE
Init BouncyCastleProvider in RsaEncryptionProvider

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/security/RsaEncryptionProvider.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/security/RsaEncryptionProvider.java
@@ -37,19 +37,23 @@ import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
+import java.security.Security;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Objects;
 
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.util.io.pem.PemReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class RsaEncryptionProvider {
+    static {
+        Security.addProvider(new BouncyCastleProvider());
+    }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RsaEncryptionProvider.class);
-
 
     private static final String RSA_TRANSFORMATION = "RSA/NONE/OAEPWithSHA3-512AndMGF1Padding";
 

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/AesKeyAwareTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/AesKeyAwareTest.java
@@ -25,22 +25,16 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.security.Security;
 import java.util.Random;
 
 import io.aiven.kafka.tieredstorage.security.AesEncryptionProvider;
 
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.BeforeAll;
 
 public class AesKeyAwareTest {
     protected static int ivSize;
     protected static SecretKeySpec secretKey;
     protected static byte[] aad;
-
-    static {
-        Security.addProvider(new BouncyCastleProvider());
-    }
 
     @BeforeAll
     static void initCrypto() {


### PR DESCRIPTION
Otherwise, it works in tests but doesn't work inside a real Kafka.

Also, removes `RsaEncryptionProvider` from `AesKeyAwareTest` where it's not needed anymore.
