### PR TITLE
Don't use chunk cache by default

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerConfig.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerConfig.java
@@ -27,7 +27,6 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.Utils;
 
 import io.aiven.kafka.tieredstorage.cache.ChunkCache;
-import io.aiven.kafka.tieredstorage.cache.UnboundInMemoryChunkCache;
 import io.aiven.kafka.tieredstorage.storage.StorageBackend;
 
 public class RemoteStorageManagerConfig extends AbstractConfig {
@@ -130,7 +129,7 @@ public class RemoteStorageManagerConfig extends AbstractConfig {
         CONFIG.define(
             CHUNK_CACHE_CONFIG,
             ConfigDef.Type.CLASS,
-            UnboundInMemoryChunkCache.class,
+            null,
             ConfigDef.Importance.MEDIUM,
             CHUNK_CACHE_DOC
         );

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerConfigTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerConfigTest.java
@@ -50,6 +50,7 @@ class RemoteStorageManagerConfigTest {
         assertThat(config.encryptionPrivateKeyFile()).isNull();
         assertThat(config.encryptionPublicKeyFile()).isNull();
         assertThat(config.keyPrefix()).isEmpty();
+        assertThat(config.chunkCache()).isNull();
     }
 
     @Test


### PR DESCRIPTION
While we don't have the disk cache, offering `UnboundInMemoryChunkCache` (without the ability to switch it off) is not great.
