### PR TITLE
fix: chunk range is not inclusive

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/Chunk.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/Chunk.java
@@ -62,7 +62,7 @@ public class Chunk {
     }
 
     BytesRange range() {
-        return BytesRange.of(transformedPosition, transformedPosition + transformedSize);
+        return BytesRange.ofFromPositionAndSize(transformedPosition, transformedSize);
     }
 
     @Override

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/transform/FetchChunkEnumeration.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/transform/FetchChunkEnumeration.java
@@ -111,7 +111,7 @@ public class FetchChunkEnumeration implements Enumeration<InputStream> {
             final int toSkip = range.from - chunkStartPosition;
             try {
                 chunkContent.skip(toSkip);
-                final int chunkSize = range.to - range.from + 1;
+                final int chunkSize = range.size();
                 chunkContent = new BoundedInputStream(chunkContent, chunkSize);
             } catch (final IOException e) {
                 throw new RuntimeException(e);

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/ChunkTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/ChunkTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ChunkTest {
+    @Test
+    void rangeIsInclusive() {
+        final Chunk chunk = new Chunk(0, 0, 10, 0, 12);
+
+        assertThat(chunk.range().from).isEqualTo(0);
+        assertThat(chunk.range().to).isEqualTo(11);
+        assertThat(chunk.range().size()).isEqualTo(12);
+    }
+}

--- a/storage/core/src/main/java/io/aiven/kafka/tieredstorage/storage/BytesRange.java
+++ b/storage/core/src/main/java/io/aiven/kafka/tieredstorage/storage/BytesRange.java
@@ -18,6 +18,7 @@ package io.aiven.kafka.tieredstorage.storage;
 
 /**
  * Byte range with from and to edges; where to cannot be less than from.
+ * Both, from and to, are inclusive positions.
  */
 public class BytesRange {
     public final int from;
@@ -32,6 +33,10 @@ public class BytesRange {
         }
         this.from = from;
         this.to = to;
+    }
+
+    public int size() {
+        return to - from + 1;
     }
 
     @Override
@@ -64,4 +69,9 @@ public class BytesRange {
     public static BytesRange of(final int from, final int to) {
         return new BytesRange(from, to);
     }
+
+    public static BytesRange ofFromPositionAndSize(final int from, final int size) {
+        return new BytesRange(from, from + size - 1);
+    }
+
 }

--- a/storage/core/src/test/java/io/aiven/kafka/tieredstorage/storage/BytesRangeTest.java
+++ b/storage/core/src/test/java/io/aiven/kafka/tieredstorage/storage/BytesRangeTest.java
@@ -24,10 +24,19 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class BytesRangeTest {
 
     @Test
+    void testMinimalRange() {
+        final BytesRange range = BytesRange.of(1, 1);
+        assertThat(range.from).isEqualTo(1);
+        assertThat(range.to).isEqualTo(1);
+        assertThat(range.size()).isEqualTo(1);
+    }
+
+    @Test
     void testProperRange() {
         final BytesRange range = BytesRange.of(1, 2);
         assertThat(range.from).isEqualTo(1);
         assertThat(range.to).isEqualTo(2);
+        assertThat(range.size()).isEqualTo(2);
     }
 
     @Test


### PR DESCRIPTION
Fixes a bug with the range produced by a chunk with no inclusive edges.
Even though it's not affecting the results of the plugin, it pulls an additional byte on each chunk fetch.
