### PR TITLE
feat(storage:s3): add s3 multi-part upload part size config

### DIFF
--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3MultiPartOutputStream.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3MultiPartOutputStream.java
@@ -47,24 +47,16 @@ public class S3MultiPartOutputStream extends OutputStream {
 
     private static final Logger log = LoggerFactory.getLogger(S3MultiPartOutputStream.class);
 
-    public static final int DEFAULT_PART_SIZE = 5 * 1024 * 1024;
-
     private final AmazonS3 client;
     private final ByteBuffer partBuffer;
     private final String bucketName;
     private final String key;
-    private final int partSize;
+    final int partSize;
 
     private final String uploadId;
     private final List<PartETag> partETags = new ArrayList<>();
 
     private boolean closed;
-
-    public S3MultiPartOutputStream(final String bucketName,
-                                   final String key,
-                                   final AmazonS3 client) {
-        this(bucketName, key, DEFAULT_PART_SIZE, client);
-    }
 
     public S3MultiPartOutputStream(final String bucketName,
                                    final String key,
@@ -102,7 +94,7 @@ public class S3MultiPartOutputStream extends OutputStream {
             partBuffer.put(source.array(), offset, transferred);
             source.position(source.position() + transferred);
             if (!partBuffer.hasRemaining()) {
-                flushBuffer(0, partSize, partSize);
+                flushBuffer(0, partSize);
             }
         }
     }
@@ -110,7 +102,7 @@ public class S3MultiPartOutputStream extends OutputStream {
     @Override
     public void close() throws IOException {
         if (partBuffer.position() > 0) {
-            flushBuffer(partBuffer.arrayOffset(), partBuffer.position(), partBuffer.position());
+            flushBuffer(partBuffer.arrayOffset(), partBuffer.position());
         }
         if (Objects.nonNull(uploadId)) {
             if (!partETags.isEmpty()) {
@@ -131,11 +123,10 @@ public class S3MultiPartOutputStream extends OutputStream {
     }
 
     private void flushBuffer(final int offset,
-                             final int length,
-                             final int partSize) throws IOException {
+                             final int actualPartSize) throws IOException {
         try {
-            final ByteArrayInputStream in = new ByteArrayInputStream(partBuffer.array(), offset, length);
-            uploadPart(in, partSize);
+            final ByteArrayInputStream in = new ByteArrayInputStream(partBuffer.array(), offset, actualPartSize);
+            uploadPart(in, actualPartSize);
             partBuffer.clear();
         } catch (final Exception e) {
             log.error("Failed to upload part in multipart upload {}, aborting transaction", uploadId, e);
@@ -145,14 +136,14 @@ public class S3MultiPartOutputStream extends OutputStream {
         }
     }
 
-    private void uploadPart(final InputStream in, final int partSize) {
+    private void uploadPart(final InputStream in, final int actualPartSize) {
         final int partNumber = partETags.size() + 1;
         final UploadPartRequest uploadPartRequest =
             new UploadPartRequest()
                 .withBucketName(bucketName)
                 .withKey(key)
                 .withUploadId(uploadId)
-                .withPartSize(partSize)
+                .withPartSize(actualPartSize)
                 .withPartNumber(partNumber)
                 .withInputStream(in);
         final UploadPartResult uploadResult = client.uploadPart(uploadPartRequest);

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfig.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3StorageConfig.java
@@ -48,6 +48,15 @@ public class S3StorageConfig extends AbstractConfig {
         + "By default, empty value means S3 library will auto-detect. "
         + "Amazon S3 uses virtual hosts by default (true), but other S3-compatible backends may differ (e.g. minio).";
 
+    private static final String S3_MULTIPART_UPLOAD_PART_SIZE_CONFIG = "s3.multipart.upload.part.size";
+    // AWS limits to 5GiB, but 2GiB are used here as ByteBuffer allocation is based on int
+    private static final String S3_MULTIPART_UPLOAD_PART_SIZE_DOC = "Size of parts in bytes to use when uploading. "
+        + "All parts but the last one will have this size. "
+        + "Valid values: between 5MiB and 2GiB";
+    static final int S3_MULTIPART_UPLOAD_PART_SIZE_MIN = 5 * 1024 * 1024; // 5MiB
+    static final int S3_MULTIPART_UPLOAD_PART_SIZE_MAX = Integer.MAX_VALUE;
+    static final int S3_MULTIPART_UPLOAD_PART_SIZE_DEFAULT = S3_MULTIPART_UPLOAD_PART_SIZE_MIN;
+
     public static final String AWS_CREDENTIALS_PROVIDER_CLASS_CONFIG = "aws.credentials.provider.class";
     private static final String AWS_CREDENTIALS_PROVIDER_CLASS_DOC = "AWS credentials provider. "
         + "If not set, AWS SDK uses the default "
@@ -89,6 +98,13 @@ public class S3StorageConfig extends AbstractConfig {
                 null,
                 ConfigDef.Importance.LOW,
                 S3_PATH_STYLE_ENABLED_DOC)
+            .define(
+                S3_MULTIPART_UPLOAD_PART_SIZE_CONFIG,
+                ConfigDef.Type.INT,
+                S3_MULTIPART_UPLOAD_PART_SIZE_DEFAULT,
+                ConfigDef.Range.between(S3_MULTIPART_UPLOAD_PART_SIZE_MIN, S3_MULTIPART_UPLOAD_PART_SIZE_MAX),
+                ConfigDef.Importance.MEDIUM,
+                S3_MULTIPART_UPLOAD_PART_SIZE_DOC)
             .define(
                 AWS_CREDENTIALS_PROVIDER_CLASS_CONFIG,
                 ConfigDef.Type.CLASS,
@@ -187,6 +203,9 @@ public class S3StorageConfig extends AbstractConfig {
         return getBoolean(S3_PATH_STYLE_ENABLED_CONFIG);
     }
 
+    public int uploadPartSize() {
+        return getInt(S3_MULTIPART_UPLOAD_PART_SIZE_CONFIG);
+    }
 
     private static class RegionValidator implements ConfigDef.Validator {
         @Override


### PR DESCRIPTION
Adds a configuration for multi-part upload. Ideally this part size should be the same as chunk size, so we gain some performance when reading[3], but this should be considered later once we have more experience with different chunk sizes.

Resolves: #233

References:

[1] Overview: https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html
[2] Multi-part upload limits: https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html
[3] https://docs.aws.amazon.com/whitepapers/latest/s3-optimizing-performance-best-practices/use-byte-range-fetches.html
> Typical sizes for byte-range requests are 8 MB or 16 MB. If objects are PUT using a multipart upload, it’s a good practice to GET them in the same part sizes (or at least aligned to part boundaries) for best performance. GET requests can directly address individual parts; for example, GET ?partNumber=N.