### PR TITLE
feat: measure object upload bytes

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
@@ -252,7 +252,12 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
         throws IOException, StorageBackendException {
         final String fileKey = objectKey.key(remoteLogSegmentMetadata, ObjectKey.Suffix.LOG);
         try (final var sis = transformFinisher.toInputStream()) {
-            uploader.upload(sis, fileKey);
+            final var bytes = uploader.upload(sis, fileKey);
+            metrics.recordObjectUpload(
+                remoteLogSegmentMetadata.remoteLogSegmentId().topicIdPartition().topicPartition(),
+                ObjectKey.Suffix.LOG,
+                bytes
+            );
         }
     }
 
@@ -260,9 +265,15 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
                                  final InputStream index,
                                  final IndexType indexType)
         throws StorageBackendException, IOException {
-        final String key = objectKey.key(remoteLogSegmentMetadata, ObjectKey.Suffix.fromIndexType(indexType));
+        final var suffix = ObjectKey.Suffix.fromIndexType(indexType);
+        final String key = objectKey.key(remoteLogSegmentMetadata, suffix);
         try (index) {
-            uploader.upload(index, key);
+            final var bytes = uploader.upload(index, key);
+            metrics.recordObjectUpload(
+                remoteLogSegmentMetadata.remoteLogSegmentId().topicIdPartition().topicPartition(),
+                suffix,
+                bytes
+            );
         }
     }
 
@@ -273,7 +284,12 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
         final String manifestFileKey = objectKey.key(remoteLogSegmentMetadata, ObjectKey.Suffix.MANIFEST);
 
         try (final ByteArrayInputStream manifestContent = new ByteArrayInputStream(manifest.getBytes())) {
-            uploader.upload(manifestContent, manifestFileKey);
+            final var bytes = uploader.upload(manifestContent, manifestFileKey);
+            metrics.recordObjectUpload(
+                remoteLogSegmentMetadata.remoteLogSegmentId().topicIdPartition().topicPartition(),
+                ObjectKey.Suffix.MANIFEST,
+                bytes
+            );
         }
     }
 

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/metrics/MetricsRegistry.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/metrics/MetricsRegistry.java
@@ -21,11 +21,20 @@ import java.util.Map;
 import org.apache.kafka.common.MetricNameTemplate;
 import org.apache.kafka.common.TopicPartition;
 
+import io.aiven.kafka.tieredstorage.ObjectKey;
+
 public class MetricsRegistry {
 
     static final String METRIC_GROUP = "remote-storage-manager-metrics";
-    static final String[] TOPIC_TAG_NAMES = {"topic"};
-    static final String[] TOPIC_PARTITION_TAG_NAMES = {"topic", "partition"};
+    static final String TAG_NAME_OBJECT_TYPE = "object-type";
+    static final String[] OBJECT_TYPE_TAG_NAMES = {TAG_NAME_OBJECT_TYPE};
+    static final String TAG_NAME_TOPIC = "topic";
+    static final String[] TOPIC_TAG_NAMES = {TAG_NAME_TOPIC};
+    static final String[] TOPIC_AND_OBJECT_TYPE_TAG_NAMES = {TAG_NAME_TOPIC, TAG_NAME_OBJECT_TYPE};
+    static final String TAG_NAME_PARTITION = "partition";
+    static final String[] TOPIC_PARTITION_TAG_NAMES = {TAG_NAME_TOPIC, TAG_NAME_PARTITION};
+    static final String[] TOPIC_PARTITION_AND_OBJECT_TYPE_TAG_NAMES =
+        {TAG_NAME_TOPIC, TAG_NAME_PARTITION, TAG_NAME_OBJECT_TYPE};
 
     // Segment copy metric names
     static final String SEGMENT_COPY = "segment-copy";
@@ -175,26 +184,123 @@ public class MetricsRegistry {
     final MetricNameTemplate segmentFetchRequestedBytesTotalByTopicPartition =
         new MetricNameTemplate(SEGMENT_FETCH_REQUESTED_BYTES_TOTAL, METRIC_GROUP, "", TOPIC_PARTITION_TAG_NAMES);
 
+    // Object upload metrics
+    static final String OBJECT_UPLOAD = "object-upload";
+    static final String OBJECT_UPLOAD_RATE = OBJECT_UPLOAD + "-rate";
+    final MetricNameTemplate objectUploadRequestsRate = new MetricNameTemplate(OBJECT_UPLOAD_RATE, METRIC_GROUP, "");
+    final MetricNameTemplate objectUploadRequestsRateByObjectType =
+        new MetricNameTemplate(OBJECT_UPLOAD_RATE, METRIC_GROUP, "", OBJECT_TYPE_TAG_NAMES);
+    final MetricNameTemplate objectUploadRequestsRateByTopic =
+        new MetricNameTemplate(OBJECT_UPLOAD_RATE, METRIC_GROUP, "", TOPIC_TAG_NAMES);
+    final MetricNameTemplate objectUploadRequestsRateByTopicAndObjectType =
+        new MetricNameTemplate(OBJECT_UPLOAD_RATE, METRIC_GROUP, "", TOPIC_AND_OBJECT_TYPE_TAG_NAMES);
+    final MetricNameTemplate objectUploadRequestsRateByTopicPartition =
+        new MetricNameTemplate(OBJECT_UPLOAD_RATE, METRIC_GROUP, "", TOPIC_PARTITION_TAG_NAMES);
+    final MetricNameTemplate objectUploadRequestsRateByTopicPartitionAndObjectType =
+        new MetricNameTemplate(OBJECT_UPLOAD_RATE, METRIC_GROUP, "", TOPIC_PARTITION_AND_OBJECT_TYPE_TAG_NAMES);
+    static final String OBJECT_UPLOAD_TOTAL = OBJECT_UPLOAD + "-total";
+    final MetricNameTemplate objectUploadRequestsTotal = new MetricNameTemplate(OBJECT_UPLOAD_TOTAL, METRIC_GROUP, "");
+    final MetricNameTemplate objectUploadRequestsTotalByObjectType =
+        new MetricNameTemplate(OBJECT_UPLOAD_TOTAL, METRIC_GROUP, "", OBJECT_TYPE_TAG_NAMES);
+    final MetricNameTemplate objectUploadRequestsTotalByTopic =
+        new MetricNameTemplate(OBJECT_UPLOAD_TOTAL, METRIC_GROUP, "", TOPIC_TAG_NAMES);
+    final MetricNameTemplate objectUploadRequestsTotalByTopicAndObjectType =
+        new MetricNameTemplate(OBJECT_UPLOAD_TOTAL, METRIC_GROUP, "", TOPIC_AND_OBJECT_TYPE_TAG_NAMES);
+    final MetricNameTemplate objectUploadRequestsTotalByTopicPartition =
+        new MetricNameTemplate(OBJECT_UPLOAD_TOTAL, METRIC_GROUP, "", TOPIC_PARTITION_TAG_NAMES);
+    final MetricNameTemplate objectUploadRequestsTotalByTopicPartitionAndObjectType =
+        new MetricNameTemplate(OBJECT_UPLOAD_TOTAL, METRIC_GROUP, "", TOPIC_PARTITION_AND_OBJECT_TYPE_TAG_NAMES);
+    static final String OBJECT_UPLOAD_BYTES = OBJECT_UPLOAD + "-bytes";
+    static final String OBJECT_UPLOAD_BYTES_RATE = OBJECT_UPLOAD_BYTES + "-rate";
+    final MetricNameTemplate objectUploadBytesRate = new MetricNameTemplate(OBJECT_UPLOAD_BYTES_RATE, METRIC_GROUP, "");
+    final MetricNameTemplate objectUploadBytesRateByObjectType =
+        new MetricNameTemplate(OBJECT_UPLOAD_BYTES_RATE, METRIC_GROUP, "", OBJECT_TYPE_TAG_NAMES);
+    final MetricNameTemplate objectUploadBytesRateByTopic =
+        new MetricNameTemplate(OBJECT_UPLOAD_BYTES_RATE, METRIC_GROUP, "", TOPIC_TAG_NAMES);
+    final MetricNameTemplate objectUploadBytesRateByTopicAndObjectType =
+        new MetricNameTemplate(OBJECT_UPLOAD_BYTES_RATE, METRIC_GROUP, "", TOPIC_AND_OBJECT_TYPE_TAG_NAMES);
+    final MetricNameTemplate objectUploadBytesRateByTopicPartition =
+        new MetricNameTemplate(OBJECT_UPLOAD_BYTES_RATE, METRIC_GROUP, "", TOPIC_PARTITION_TAG_NAMES);
+    final MetricNameTemplate objectUploadBytesRateByTopicPartitionAndObjectType =
+        new MetricNameTemplate(OBJECT_UPLOAD_BYTES_RATE, METRIC_GROUP, "", TOPIC_PARTITION_AND_OBJECT_TYPE_TAG_NAMES);
+    public static final String OBJECT_UPLOAD_BYTES_TOTAL = OBJECT_UPLOAD_BYTES + "-total";
+    final MetricNameTemplate objectUploadBytesTotal =
+        new MetricNameTemplate(OBJECT_UPLOAD_BYTES_TOTAL, METRIC_GROUP, "");
+    final MetricNameTemplate objectUploadBytesTotalByObjectType =
+        new MetricNameTemplate(OBJECT_UPLOAD_BYTES_TOTAL, METRIC_GROUP, "", OBJECT_TYPE_TAG_NAMES);
+    final MetricNameTemplate objectUploadBytesTotalByTopic =
+        new MetricNameTemplate(OBJECT_UPLOAD_BYTES_TOTAL, METRIC_GROUP, "", TOPIC_TAG_NAMES);
+    final MetricNameTemplate objectUploadBytesTotalByTopicAndObjectType =
+        new MetricNameTemplate(OBJECT_UPLOAD_BYTES_TOTAL, METRIC_GROUP, "", TOPIC_AND_OBJECT_TYPE_TAG_NAMES);
+    final MetricNameTemplate objectUploadBytesTotalByTopicPartition =
+        new MetricNameTemplate(OBJECT_UPLOAD_BYTES_TOTAL, METRIC_GROUP, "", TOPIC_PARTITION_TAG_NAMES);
+    final MetricNameTemplate objectUploadBytesTotalByTopicPartitionAndObjectType =
+        new MetricNameTemplate(OBJECT_UPLOAD_BYTES_TOTAL, METRIC_GROUP, "", TOPIC_PARTITION_AND_OBJECT_TYPE_TAG_NAMES);
+
     public static String sensorName(final String name) {
         return name;
     }
 
+    public static String sensorNameByObjectType(final ObjectKey.Suffix suffix, final String name) {
+        return TAG_NAME_OBJECT_TYPE + "." + suffix.value + "." + name;
+    }
+
     public static String sensorNameByTopic(final TopicPartition topicPartition, final String name) {
-        return "topic." + topicPartition.topic() + "." + name;
+        return TAG_NAME_TOPIC + "." + topicPartition.topic() + "." + name;
+    }
+
+    public static String sensorNameByTopicAndObjectType(final TopicPartition topicPartition,
+                                                        final ObjectKey.Suffix suffix,
+                                                        final String name) {
+        return TAG_NAME_TOPIC + "." + topicPartition.topic() + "."
+            + TAG_NAME_OBJECT_TYPE + "." + suffix.value
+            + "." + name;
     }
 
     public static String sensorNameByTopicPartition(final TopicPartition topicPartition, final String name) {
-        return "topic." + topicPartition.topic() + ".partition." + topicPartition.partition() + "." + name;
+        return TAG_NAME_TOPIC + "." + topicPartition.topic()
+            + "." + TAG_NAME_PARTITION + "." + topicPartition.partition()
+            + "." + name;
+    }
+
+    public static String sensorNameByTopicPartitionAndObjectType(final TopicPartition topicPartition,
+                                                                 final ObjectKey.Suffix suffix,
+                                                                 final String name) {
+        return TAG_NAME_TOPIC + "." + topicPartition.topic()
+            + "." + TAG_NAME_PARTITION + "." + topicPartition.partition()
+            + "." + TAG_NAME_OBJECT_TYPE + "." + suffix.value
+            + "." + name;
     }
 
     static Map<String, String> topicTags(final TopicPartition topicPartition) {
-        return Map.of("topic", topicPartition.topic());
+        return Map.of(TAG_NAME_TOPIC, topicPartition.topic());
+    }
+
+    static Map<String, String> topicAndObjectTypeTags(final TopicPartition topicPartition,
+                                                      final ObjectKey.Suffix suffix) {
+        return Map.of(
+            TAG_NAME_TOPIC, topicPartition.topic(),
+            TAG_NAME_OBJECT_TYPE, suffix.value
+        );
     }
 
     static Map<String, String> topicPartitionTags(final TopicPartition topicPartition) {
         return Map.of(
-            "topic", topicPartition.topic(),
-            "partition", String.valueOf(topicPartition.partition())
+            TAG_NAME_TOPIC, topicPartition.topic(),
+            TAG_NAME_PARTITION, String.valueOf(topicPartition.partition())
         );
+    }
+
+    static Map<String, String> topicPartitionAndObjectTypeTags(final TopicPartition topicPartition,
+                                                               final ObjectKey.Suffix suffix) {
+        return Map.of(
+            TAG_NAME_TOPIC, topicPartition.topic(),
+            TAG_NAME_PARTITION, String.valueOf(topicPartition.partition()),
+            TAG_NAME_OBJECT_TYPE, suffix.value
+        );
+    }
+
+    static Map<String, String> objectTypeTags(final ObjectKey.Suffix suffix) {
+        return Map.of(TAG_NAME_OBJECT_TYPE, suffix.value);
     }
 }

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/metrics/SensorProvider.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/metrics/SensorProvider.java
@@ -44,6 +44,12 @@ public class SensorProvider {
 
     public SensorProvider(final Metrics metrics,
                           final String name,
+                          final Sensor.RecordingLevel recordingLevel) {
+        this(metrics, name, Collections::emptyMap, recordingLevel);
+    }
+
+    public SensorProvider(final Metrics metrics,
+                          final String name,
                           final Supplier<Map<String, String>> tagsSupplier) {
         this(metrics, name, tagsSupplier, Sensor.RecordingLevel.INFO);
     }

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/NoopStorageBackend.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/NoopStorageBackend.java
@@ -37,7 +37,8 @@ public class NoopStorageBackend implements StorageBackend {
     }
 
     @Override
-    public void upload(final InputStream inputStream, final String key) throws StorageBackendException {
+    public long upload(final InputStream inputStream, final String key) throws StorageBackendException {
+        return 0;
     }
 
     @Override

--- a/storage/core/src/main/java/io/aiven/kafka/tieredstorage/storage/ObjectUploader.java
+++ b/storage/core/src/main/java/io/aiven/kafka/tieredstorage/storage/ObjectUploader.java
@@ -21,7 +21,8 @@ import java.io.InputStream;
 public interface ObjectUploader {
     /**
      * @param inputStream content to upload. Not closed as part of the upload.
-     * @param key path to an object within a storage backend.
+     * @param key         path to an object within a storage backend.
+     * @return number of bytes uploaded
      */
-    void upload(InputStream inputStream, String key) throws StorageBackendException;
+    long upload(InputStream inputStream, String key) throws StorageBackendException;
 }

--- a/storage/core/src/testFixtures/java/io/aiven/kafka/tieredstorage/storage/BaseStorageTest.java
+++ b/storage/core/src/testFixtures/java/io/aiven/kafka/tieredstorage/storage/BaseStorageTest.java
@@ -35,7 +35,8 @@ public abstract class BaseStorageTest {
     void testUploadFetchDelete() throws IOException, StorageBackendException {
         final byte[] data = "some file".getBytes();
         final InputStream file = new ByteArrayInputStream(data);
-        storage().upload(file, TOPIC_PARTITION_SEGMENT_KEY);
+        final long size = storage().upload(file, TOPIC_PARTITION_SEGMENT_KEY);
+        assertThat(size).isEqualTo(data.length);
 
         try (final InputStream fetch = storage().fetch(TOPIC_PARTITION_SEGMENT_KEY)) {
             final String r = new String(fetch.readAllBytes());
@@ -59,7 +60,8 @@ public abstract class BaseStorageTest {
     void testUploadANewFile() throws StorageBackendException, IOException {
         final String content = "content";
         final ByteArrayInputStream in = new ByteArrayInputStream(content.getBytes());
-        storage().upload(in, TOPIC_PARTITION_SEGMENT_KEY);
+        final long size = storage().upload(in, TOPIC_PARTITION_SEGMENT_KEY);
+        assertThat(size).isEqualTo(content.length());
 
         assertThat(in).isEmpty();
         in.close();

--- a/storage/filesystem/src/main/java/io/aiven/kafka/tieredstorage/storage/filesystem/FileSystemStorage.java
+++ b/storage/filesystem/src/main/java/io/aiven/kafka/tieredstorage/storage/filesystem/FileSystemStorage.java
@@ -18,10 +18,10 @@ package io.aiven.kafka.tieredstorage.storage.filesystem;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Map;
 
 import io.aiven.kafka.tieredstorage.storage.BytesRange;
@@ -47,13 +47,12 @@ public class FileSystemStorage implements StorageBackend {
     }
 
     @Override
-    public void upload(final InputStream inputStream, final String key) throws StorageBackendException {
+    public long upload(final InputStream inputStream, final String key) throws StorageBackendException {
         try {
             final Path path = fsRoot.resolve(key);
             Files.createDirectories(path.getParent());
-            try (final OutputStream outputStream = Files.newOutputStream(path)) {
-                inputStream.transferTo(outputStream);
-            }
+            Files.copy(inputStream, path, StandardCopyOption.REPLACE_EXISTING);
+            return Files.size(path);
         } catch (final IOException e) {
             throw new StorageBackendException("Failed to upload " + key, e);
         }

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3MultiPartOutputStream.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3MultiPartOutputStream.java
@@ -57,6 +57,7 @@ public class S3MultiPartOutputStream extends OutputStream {
     private final List<PartETag> partETags = new ArrayList<>();
 
     private boolean closed;
+    private long processedBytes = 0L;
 
     public S3MultiPartOutputStream(final String bucketName,
                                    final String key,
@@ -93,6 +94,7 @@ public class S3MultiPartOutputStream extends OutputStream {
                 final int offset = source.arrayOffset() + source.position();
                 // TODO: get rid of this array copying
                 partBuffer.put(source.array(), offset, transferred);
+                processedBytes += transferred;
                 source.position(source.position() + transferred);
                 if (!partBuffer.hasRemaining()) {
                     flushBuffer(0, partSize);
@@ -167,5 +169,9 @@ public class S3MultiPartOutputStream extends OutputStream {
                 .withInputStream(in);
         final UploadPartResult uploadResult = client.uploadPart(uploadPartRequest);
         partETags.add(uploadResult.getPartETag());
+    }
+
+    public long processedBytes() {
+        return processedBytes;
     }
 }

--- a/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3Storage.java
+++ b/storage/s3/src/main/java/io/aiven/kafka/tieredstorage/storage/s3/S3Storage.java
@@ -46,9 +46,10 @@ public class S3Storage implements StorageBackend {
     }
 
     @Override
-    public void upload(final InputStream inputStream, final String key) throws StorageBackendException {
+    public long upload(final InputStream in, final String key) throws StorageBackendException {
         try (final var out = s3OutputStream(key)) {
-            inputStream.transferTo(out);
+            in.transferTo(out);
+            return out.processedBytes();
         } catch (final AmazonS3Exception | IOException e) {
             throw new StorageBackendException("Failed to upload " + key, e);
         }


### PR DESCRIPTION
Changes:
- To enable metrics to capture the number of bytes uploaded to storage backends (e.g. after transforms), `upload` is expanded to return the number of bytes uploaded.
- Metrics to measure object uploads per suffix type are added.