### PR TITLE
feat(metrics): add metrics for delete path

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/RemoteStorageManager.java
@@ -306,6 +306,8 @@ public class RemoteStorageManager implements org.apache.kafka.server.log.remote.
     @Override
     public void deleteLogSegmentData(final RemoteLogSegmentMetadata remoteLogSegmentMetadata)
         throws RemoteStorageException {
+        metrics.recordSegmentDelete(remoteLogSegmentMetadata.segmentSizeInBytes());
+
         try {
             for (final ObjectKey.Suffix suffix : ObjectKey.Suffix.values()) {
                 final String key = objectKey.key(remoteLogSegmentMetadata, suffix);

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/metrics/Metrics.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/metrics/Metrics.java
@@ -43,6 +43,9 @@ public class Metrics {
     private final Sensor segmentCopyTime;
     private final Sensor segmentCopyBytes;
 
+    private final Sensor segmentDeleteRequests;
+    private final Sensor segmentDeleteBytes;
+
     private final Sensor segmentFetchPerSec;
 
     public Metrics(final Time time) {
@@ -68,6 +71,14 @@ public class Metrics {
         segmentCopyTime.add(metrics.metricName("segment-copy-time-avg", metricGroup), new Avg());
         segmentCopyTime.add(metrics.metricName("segment-copy-time-max", metricGroup), new Max());
 
+        segmentDeleteRequests = metrics.sensor("segment-delete");
+        segmentDeleteRequests.add(metrics.metricName("segment-delete-rate", metricGroup), new Rate());
+        segmentDeleteRequests.add(metrics.metricName("segment-delete-total", metricGroup), new CumulativeCount());
+
+        segmentDeleteBytes = metrics.sensor("segment-delete-bytes");
+        segmentDeleteBytes.add(metrics.metricName("segment-delete-bytes-rate", metricGroup), new Rate());
+        segmentDeleteBytes.add(metrics.metricName("segment-delete-bytes-total", metricGroup), new CumulativeSum());
+
         segmentFetchPerSec = metrics.sensor("segment-fetch");
         segmentFetchPerSec.add(metrics.metricName("segment-fetch-rate", metricGroup), new Rate());
     }
@@ -75,6 +86,11 @@ public class Metrics {
     public void recordSegmentCopy(final int bytes) {
         segmentCopyRequests.record();
         segmentCopyBytes.record(bytes);
+    }
+
+    public void recordSegmentDelete(final int bytes) {
+        segmentDeleteRequests.record();
+        segmentDeleteBytes.record(bytes);
     }
 
     public void recordSegmentCopyTime(final long startMs, final long endMs) {

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerMetricsTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/RemoteStorageManagerMetricsTest.java
@@ -124,5 +124,19 @@ class RemoteStorageManagerMetricsTest {
 
         assertThat((double) MBEAN_SERVER.getAttribute(segmentCopyPerSecName, "segment-fetch-rate"))
             .isEqualTo(1.0 / METRIC_TIME_WINDOW_SEC);
+
+        rsm.deleteLogSegmentData(REMOTE_LOG_SEGMENT_METADATA);
+        rsm.deleteLogSegmentData(REMOTE_LOG_SEGMENT_METADATA);
+
+        assertThat((double) MBEAN_SERVER.getAttribute(segmentCopyPerSecName, "segment-delete-rate"))
+            .isEqualTo(2.0 / METRIC_TIME_WINDOW_SEC);
+        assertThat((double) MBEAN_SERVER.getAttribute(segmentCopyPerSecName, "segment-delete-total"))
+            .isEqualTo(2.0);
+
+        assertThat((double) MBEAN_SERVER.getAttribute(segmentCopyPerSecName, "segment-delete-bytes-rate"))
+            .isEqualTo(20.0 / METRIC_TIME_WINDOW_SEC);
+        assertThat((double) MBEAN_SERVER.getAttribute(segmentCopyPerSecName, "segment-delete-bytes-total"))
+            .isEqualTo(20.0);
+
     }
 }


### PR DESCRIPTION
Record metrics for:
- Delete requests (req/sec)
- Bytes requested to delete (bytes/sec)

This is based on RSM metadata, and not actual deletes. Those would be measured at the storage layer.
