### PR TITLE
fix(cache:disk): fail when base directory does not exist

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/chunkmanager/ChunkManagerFactoryConfig.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/chunkmanager/ChunkManagerFactoryConfig.java
@@ -49,6 +49,7 @@ public class ChunkManagerFactoryConfig extends AbstractConfig {
         super(CONFIG, originals);
     }
 
+    @SuppressWarnings("unchecked")
     public Class<ChunkCache<?>> cacheClass() {
         return (Class<ChunkCache<?>>) getClass(CHUNK_CACHE_CONFIG);
     }

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/DiskBasedChunkCacheConfig.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/chunkmanager/cache/DiskBasedChunkCacheConfig.java
@@ -28,7 +28,8 @@ import org.apache.commons.io.FileUtils;
 
 public class DiskBasedChunkCacheConfig extends ChunkCacheConfig {
     private static final String CACHE_PATH_CONFIG = "path";
-    private static final String CACHE_PATH_DOC = "Cache directory";
+    private static final String CACHE_PATH_DOC = "Cache base directory. "
+        + "It is required to exist and be writable prior to the execution of the plugin.";
 
     public static final String TEMP_CACHE_DIRECTORY = "temp";
     public static final String CACHE_DIRECTORY = "cache";


### PR DESCRIPTION
Currently, disk-based cache is only validating if directory exist to delete it and re-create child directories.

This approach is inconsistent with how other paths are defined in the plugin, requiring the directory to exist prior to the start of the plugin. The plugin does this to avoid messing with the existing permissions around the preparation of the directory.

Applying the fixes to fail if directory doesn't exist and some additional refactoring.