### PR TITLE
Minor fix for Jira sync

### DIFF
--- a/.github/workflows/create-ticket.yml
+++ b/.github/workflows/create-ticket.yml
@@ -31,6 +31,7 @@ jobs:
         issuetype: Task
         summary: "[TS] ${{ github.event.issue.title }}"
         description: ${{ github.event.issue.body }}
+        Components: "Service - Kafka"
 
     - name: Update issue
       uses: actions-cool/issues-helper@v3


### PR DESCRIPTION
About this change - What it does
This fixes a small issue with the Jira sync script, where it's needed for HH projects so specify a component for a the ticket being created
Resolves: #xxxxx
Why this way
