### PR TITLE
Identify encryption key in manifest

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/security/EncryptedDataKey.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/security/EncryptedDataKey.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.security;
+
+import java.util.Base64;
+import java.util.Objects;
+
+public class EncryptedDataKey {
+    public final String keyEncryptionKeyId;
+    public final byte[] encryptedDataKey;
+
+    public EncryptedDataKey(final String keyEncryptionKeyId, final byte[] encryptedDataKey) {
+        this.keyEncryptionKeyId = Objects.requireNonNull(keyEncryptionKeyId, "keyEncryptionKeyId cannot be null");
+        if (keyEncryptionKeyId.isBlank()) {
+            throw new IllegalArgumentException("keyEncryptionKeyId cannot be blank");
+        }
+        this.encryptedDataKey = Objects.requireNonNull(encryptedDataKey, "encryptedDataKey cannot be null");
+        if (this.encryptedDataKey.length == 0) {
+            throw new IllegalArgumentException("encryptedDataKey cannot be empty");
+        }
+    }
+
+    public static EncryptedDataKey parse(final String keyText) {
+        final int colonI = keyText.indexOf(':');
+        if (colonI < 0) {
+            throw new IllegalArgumentException("Malformed encrypted data key string: " + keyText);
+        }
+        // Sanity check for more than one ':'
+        final int lastColonI = keyText.lastIndexOf(':');
+        if (lastColonI != colonI) {
+            throw new IllegalArgumentException("Malformed encrypted data key string: " + keyText);
+        }
+
+        final String keyEncryptionKeyId = keyText.substring(0, colonI);
+        final String dataKeyBase64 = keyText.substring(colonI + 1);
+        try {
+            final byte[] decoded = Base64.getDecoder().decode(dataKeyBase64);
+            return new EncryptedDataKey(keyEncryptionKeyId, decoded);
+        } catch (final IllegalArgumentException e) {
+            throw new IllegalArgumentException("Malformed encrypted data key string: " + keyText, e);
+        }
+    }
+
+    public String serialize() {
+        return keyEncryptionKeyId + ":" + Base64.getEncoder().encodeToString(encryptedDataKey);
+    }
+
+    @Override
+    public String toString() {
+        return "EncryptedDataKey(" + serialize() + ")";
+    }
+}

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/security/RsaEncryptionProvider.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/security/RsaEncryptionProvider.java
@@ -20,62 +20,44 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
-import javax.crypto.SecretKey;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.security.InvalidKeyException;
 import java.security.Key;
-import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
-import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.Security;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.PKCS8EncodedKeySpec;
-import java.security.spec.X509EncodedKeySpec;
+import java.util.Map;
 import java.util.Objects;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.util.io.pem.PemReader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class RsaEncryptionProvider {
     static {
         Security.addProvider(new BouncyCastleProvider());
     }
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(RsaEncryptionProvider.class);
-
     private static final String RSA_TRANSFORMATION = "RSA/NONE/OAEPWithSHA3-512AndMGF1Padding";
 
+    private final String activeKeyId;
+    private final Map<String, KeyPair> keyring;
+    private final PublicKey encryptionPublicKey;
 
-    private final KeyPair rsaKeyPair;
-
-    private RsaEncryptionProvider(final KeyPair rsaKeyPair) {
-        this.rsaKeyPair = rsaKeyPair;
+    public RsaEncryptionProvider(final String activeKeyId, final Map<String, KeyPair> keyring) {
+        this.activeKeyId = Objects.requireNonNull(activeKeyId, "keyId cannot be null");
+        this.keyring = Objects.requireNonNull(keyring, "keyring cannot be null");
+        this.encryptionPublicKey = keyring.get(activeKeyId).getPublic();
+        if (encryptionPublicKey == null) {
+            throw new IllegalArgumentException("Key ID " + activeKeyId + " is not in keyring");
+        }
     }
 
-    public static RsaEncryptionProvider of(final Path rsaPublicKey, final Path rsaPrivateKey) {
-        LOGGER.info("Read RSA keys");
-        Objects.requireNonNull(rsaPublicKey, "rsaPublicKey hasn't been set");
-        Objects.requireNonNull(rsaPrivateKey, "rsaPrivateKey hasn't been set");
-        final KeyPair rsaKeyPair = RsaKeysReader.readRsaKeyPair(rsaPublicKey, rsaPrivateKey);
-        return new RsaEncryptionProvider(rsaKeyPair);
-    }
-
-    public byte[] encryptDataKey(final SecretKey dataKey) {
+    public EncryptedDataKey encryptDataKey(final byte[] dataKey) {
         try {
-            final var cipher = createEncryptingCipher(rsaKeyPair.getPublic());
-            return cipher.doFinal(dataKey.getEncoded());
+            final var cipher = createEncryptingCipher(encryptionPublicKey);
+            return new EncryptedDataKey(activeKeyId, cipher.doFinal(dataKey));
         } catch (final IllegalBlockSizeException | BadPaddingException e) {
             throw new RuntimeException("Couldn't encrypt AES key", e);
         }
@@ -93,10 +75,15 @@ public final class RsaEncryptionProvider {
         }
     }
 
-    public byte[] decryptDataKey(final byte[] bytes) {
+    public byte[] decryptDataKey(final EncryptedDataKey encryptedKeyString) {
         try {
-            final Cipher cipher = createDecryptingCipher(rsaKeyPair.getPrivate());
-            return cipher.doFinal(bytes);
+            final KeyPair keyPair = keyring.get(encryptedKeyString.keyEncryptionKeyId);
+            if (keyPair == null) {
+                throw new IllegalArgumentException("Unknown key " + encryptedKeyString.keyEncryptionKeyId);
+            }
+
+            final Cipher cipher = createDecryptingCipher(keyPair.getPrivate());
+            return cipher.doFinal(encryptedKeyString.encryptedDataKey);
         } catch (final IllegalBlockSizeException | BadPaddingException e) {
             throw new RuntimeException("Couldn't decrypt AES key", e);
         }
@@ -110,56 +97,6 @@ public final class RsaEncryptionProvider {
         } catch (final NoSuchAlgorithmException | NoSuchPaddingException
                        | InvalidKeyException | NoSuchProviderException e) {
             throw new RuntimeException("Couldn't create decrypt cipher", e);
-        }
-    }
-
-    static class RsaKeysReader {
-
-        static KeyPair readRsaKeyPair(final Path publicKeyPath, final Path privateKeyPath) {
-            try (final InputStream publicKeyIn = Files.newInputStream(publicKeyPath);
-                 final InputStream privateKeyIn = Files.newInputStream(privateKeyPath)) {
-                return readRsaKeyPair(publicKeyIn, privateKeyIn);
-            } catch (final IOException e) {
-                throw new IllegalArgumentException("Couldn't read RSA key pair paths", e);
-            }
-        }
-
-        static KeyPair readRsaKeyPair(final InputStream publicKeyIn, final InputStream privateKeyIn) {
-            try {
-                final var publicKey = readPublicKey(publicKeyIn);
-                final var privateKey = readPrivateKey(privateKeyIn);
-                return new KeyPair(publicKey, privateKey);
-            } catch (final NoSuchAlgorithmException | InvalidKeySpecException e) {
-                throw new IllegalArgumentException("Couldn't read RSA key pair", e);
-            }
-        }
-
-        private static PublicKey readPublicKey(final InputStream in)
-            throws NoSuchAlgorithmException, InvalidKeySpecException {
-            final var pemContent = readPemContent(new InputStreamReader(in));
-            final var keySpec = new X509EncodedKeySpec(pemContent);
-            final var kf = KeyFactory.getInstance("RSA");
-            return kf.generatePublic(keySpec);
-        }
-
-        private static PrivateKey readPrivateKey(final InputStream in)
-            throws NoSuchAlgorithmException, InvalidKeySpecException {
-            final var pemContent = readPemContent(new InputStreamReader(in));
-            final var keySpec = new PKCS8EncodedKeySpec(pemContent);
-            final var kf = KeyFactory.getInstance("RSA");
-            return kf.generatePrivate(keySpec);
-        }
-
-        private static byte[] readPemContent(final Reader reader) {
-            try (final var pemReader = new PemReader(reader)) {
-                final var pemObject = pemReader.readPemObject();
-                if (Objects.isNull(pemObject)) {
-                    throw new IllegalArgumentException("Couldn't read PEM file");
-                }
-                return pemObject.getContent();
-            } catch (final IOException e) {
-                throw new IllegalArgumentException("Couldn't read PEM file", e);
-            }
         }
     }
 }

--- a/core/src/main/java/io/aiven/kafka/tieredstorage/security/RsaKeyReader.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/security/RsaKeyReader.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.security;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Objects;
+
+import org.bouncycastle.util.io.pem.PemReader;
+
+public class RsaKeyReader {
+    public static KeyPair read(final Path publicKeyPath, final Path privateKeyPath) {
+        try (final InputStream publicKeyIn = Files.newInputStream(publicKeyPath);
+             final InputStream privateKeyIn = Files.newInputStream(privateKeyPath)) {
+            return read(publicKeyIn, privateKeyIn);
+        } catch (final IOException e) {
+            throw new IllegalArgumentException("Couldn't read RSA key pair paths", e);
+        }
+    }
+
+    static KeyPair read(final InputStream publicKeyIn, final InputStream privateKeyIn) {
+        try {
+            final var publicKey = readPublicKey(publicKeyIn);
+            final var privateKey = readPrivateKey(privateKeyIn);
+            return new KeyPair(publicKey, privateKey);
+        } catch (final NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new IllegalArgumentException("Couldn't read RSA key pair", e);
+        }
+    }
+
+    private static PublicKey readPublicKey(final InputStream in)
+        throws NoSuchAlgorithmException, InvalidKeySpecException {
+        final var pemContent = readPemContent(new InputStreamReader(in));
+        final var keySpec = new X509EncodedKeySpec(pemContent);
+        final var kf = KeyFactory.getInstance("RSA");
+        return kf.generatePublic(keySpec);
+    }
+
+    private static PrivateKey readPrivateKey(final InputStream in)
+        throws NoSuchAlgorithmException, InvalidKeySpecException {
+        final var pemContent = readPemContent(new InputStreamReader(in));
+        final var keySpec = new PKCS8EncodedKeySpec(pemContent);
+        final var kf = KeyFactory.getInstance("RSA");
+        return kf.generatePrivate(keySpec);
+    }
+
+    private static byte[] readPemContent(final Reader reader) {
+        try (final var pemReader = new PemReader(reader)) {
+            final var pemObject = pemReader.readPemObject();
+            if (Objects.isNull(pemObject)) {
+                throw new IllegalArgumentException("Couldn't read PEM file");
+            }
+            return pemObject.getContent();
+        } catch (final IOException e) {
+            throw new IllegalArgumentException("Couldn't read PEM file", e);
+        }
+    }
+}

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/security/EncryptedDataKeyTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/security/EncryptedDataKeyTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage.security;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class EncryptedDataKeyTest {
+    static final byte[] SOME_BYTES = {0, 1, 2, 3};
+
+    @Test
+    void constructorNoNullId() {
+        assertThatThrownBy(() -> new EncryptedDataKey(null, SOME_BYTES))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("keyEncryptionKeyId cannot be null");
+    }
+
+    @Test
+    void constructorNoBlankId() {
+        assertThatThrownBy(() -> new EncryptedDataKey("", SOME_BYTES))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("keyEncryptionKeyId cannot be blank");
+    }
+
+    @Test
+    void constructorNoNullKey() {
+        assertThatThrownBy(() -> new EncryptedDataKey("id", null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("encryptedDataKey cannot be null");
+    }
+
+    @Test
+    void constructorNoEmptyKey() {
+        assertThatThrownBy(() -> new EncryptedDataKey("id", new byte[0]))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("encryptedDataKey cannot be empty");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "AAECAw==",  // no :
+        "xx::AAECAw==",  // double ::
+        "xx:AAECAw==:xx",  // two :
+        "id:INVALIDBASE64", // invalid Base64
+        "id:",  // empty key
+        ":",  // empty id and key
+        ":AAECAw==",  // empty id
+        "  :AAECAw=="  // blank id
+    })
+    void parseBadStrings(final String badString) {
+        assertThatThrownBy(() -> EncryptedDataKey.parse(badString))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Malformed encrypted data key string: " + badString);
+    }
+
+    @Test
+    void parseGoodString() {
+        final EncryptedDataKey parsed = EncryptedDataKey.parse("id:AAECAw==");
+        assertThat(parsed.keyEncryptionKeyId).isEqualTo("id");
+        assertThat(parsed.encryptedDataKey).isEqualTo(SOME_BYTES);
+    }
+
+    @Test
+    void serialize() {
+        final EncryptedDataKey encryptedDataKey = new EncryptedDataKey("id", SOME_BYTES);
+        assertThat(encryptedDataKey.serialize()).isEqualTo("id:AAECAw==");
+    }
+}

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/security/RsaKeyReaderTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/security/RsaKeyReaderTest.java
@@ -31,12 +31,12 @@ import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class RsaKeysReaderTest extends RsaKeyAwareTest {
+class RsaKeyReaderTest extends RsaKeyAwareTest {
 
     @Test
     public void failsForUnknownPaths() {
         assertThatThrownBy(
-            () -> RsaEncryptionProvider.RsaKeysReader.readRsaKeyPair(Paths.get("./some"), Paths.get("./path")))
+            () -> RsaKeyReader.read(Paths.get("./some"), Paths.get("./path")))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Couldn't read RSA key pair paths");
     }
@@ -51,7 +51,7 @@ class RsaKeysReaderTest extends RsaKeyAwareTest {
         writePemFile(dsaPrivateKeyPem, new PKCS8EncodedKeySpec(dsaKeyPair.getPrivate().getEncoded()));
 
         assertThatThrownBy(
-            () -> RsaEncryptionProvider.RsaKeysReader.readRsaKeyPair(dsaPublicKeyPem, dsaPrivateKeyPem))
+            () -> RsaKeyReader.read(dsaPublicKeyPem, dsaPrivateKeyPem))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Couldn't read RSA key pair");
     }
@@ -62,7 +62,7 @@ class RsaKeysReaderTest extends RsaKeyAwareTest {
             Files.createFile(tmpDir.resolve("empty_public_key.pem"));
 
         assertThatThrownBy(
-            () -> RsaEncryptionProvider.RsaKeysReader.readRsaKeyPair(emptyPublicKeyPemFile, privateKeyPem))
+            () -> RsaKeyReader.read(emptyPublicKeyPemFile, privateKeyPem))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Couldn't read PEM file");
     }
@@ -73,7 +73,7 @@ class RsaKeysReaderTest extends RsaKeyAwareTest {
             Files.createFile(tmpDir.resolve("empty_private_key.pem"));
 
         assertThatThrownBy(
-            () -> RsaEncryptionProvider.RsaKeysReader.readRsaKeyPair(publicKeyPem, emptyPrivateKeyPemFile))
+            () -> RsaKeyReader.read(publicKeyPem, emptyPrivateKeyPemFile))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Couldn't read PEM file");
     }


### PR DESCRIPTION
This commit is a preparation for changing how the plugin deals with encryption keys. The idea will be that there will be several RSA key encryption keys (KEK) provided in the configuration. When a data encryption key (DEK) is encrypted and written to the manifest, it comes with the ID of the KEK that encrypted it. When it's time to decrypt, the corresponding KEK is found by ID in the keyring and used for decryption.

This commit doesn't yet introduce multiple keys on the configuration level, but set's up all the necessary internal mechanics and uses a static KEK ID for now.

There will be a follow-up that actually introduces the keyring on the configuration level.