### PR TITLE
Provide keyring in configuration

### DIFF
--- a/core/src/main/java/io/aiven/kafka/tieredstorage/KeyPairPaths.java
+++ b/core/src/main/java/io/aiven/kafka/tieredstorage/KeyPairPaths.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.tieredstorage;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+public class KeyPairPaths {
+    public final Path publicKey;
+    public final Path privateKey;
+
+    public KeyPairPaths(final Path publicKey, final Path privateKey) {
+        this.publicKey = Objects.requireNonNull(publicKey, "publicKey cannot be null");
+        this.privateKey = Objects.requireNonNull(privateKey, "privateKey cannot be null");
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final KeyPairPaths that = (KeyPairPaths) o;
+        return Objects.equals(publicKey, that.publicKey) && Objects.equals(privateKey, that.privateKey);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(publicKey, privateKey);
+    }
+
+    @Override
+    public String toString() {
+        return "KeyPairPaths("
+            + "publicKey=" + publicKey
+            + ", privateKey=" + privateKey
+            + ")";
+    }
+}

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/RsaKeyAwareTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/RsaKeyAwareTest.java
@@ -29,6 +29,9 @@ import java.security.Security;
 import java.security.spec.EncodedKeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.Map;
+
+import io.aiven.kafka.tieredstorage.security.RsaKeyReader;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.util.io.pem.PemObject;
@@ -40,9 +43,13 @@ public abstract class RsaKeyAwareTest {
 
     public static KeyPair rsaKeyPair;
 
+    public static final String KEY_ENCRYPTION_KEY_ID = "static-key-id";
+
     public static Path publicKeyPem;
 
     public static Path privateKeyPem;
+
+    public static Map<String, KeyPair> keyRing;
 
     static {
         Security.addProvider(new BouncyCastleProvider());
@@ -60,6 +67,8 @@ public abstract class RsaKeyAwareTest {
 
         writePemFile(publicKeyPem, new X509EncodedKeySpec(rsaKeyPair.getPublic().getEncoded()));
         writePemFile(privateKeyPem, new PKCS8EncodedKeySpec(rsaKeyPair.getPrivate().getEncoded()));
+
+        keyRing = Map.of(KEY_ENCRYPTION_KEY_ID, RsaKeyReader.read(publicKeyPem, privateKeyPem));
     }
 
     protected static void writePemFile(final Path path, final EncodedKeySpec encodedKeySpec) throws IOException {

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/manifest/SegmentManifestV1SerdeTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/manifest/SegmentManifestV1SerdeTest.java
@@ -20,7 +20,6 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
 import java.util.Base64;
-import java.util.Map;
 
 import io.aiven.kafka.tieredstorage.RsaKeyAwareTest;
 import io.aiven.kafka.tieredstorage.manifest.index.FixedSizeChunkIndex;
@@ -28,7 +27,6 @@ import io.aiven.kafka.tieredstorage.manifest.serde.DataKeyDeserializer;
 import io.aiven.kafka.tieredstorage.manifest.serde.DataKeySerializer;
 import io.aiven.kafka.tieredstorage.security.EncryptedDataKey;
 import io.aiven.kafka.tieredstorage.security.RsaEncryptionProvider;
-import io.aiven.kafka.tieredstorage.security.RsaKeyReader;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -43,7 +41,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SegmentManifestV1SerdeTest extends RsaKeyAwareTest {
     static final FixedSizeChunkIndex INDEX =
         new FixedSizeChunkIndex(100, 1000, 110, 110);
-    static final String KEY_ENCRYPTION_KEY_ID = "static-key-id";
     static final SecretKey DATA_KEY = new SecretKeySpec(new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, "AES");
     static final byte[] AAD = {10, 11, 12, 13};
 
@@ -66,9 +63,7 @@ class SegmentManifestV1SerdeTest extends RsaKeyAwareTest {
         mapper = new ObjectMapper();
         mapper.registerModule(new Jdk8Module());
 
-        rsaEncryptionProvider = new RsaEncryptionProvider(
-            KEY_ENCRYPTION_KEY_ID,
-            Map.of(KEY_ENCRYPTION_KEY_ID, RsaKeyReader.read(publicKeyPem, privateKeyPem)));
+        rsaEncryptionProvider = new RsaEncryptionProvider(KEY_ENCRYPTION_KEY_ID, keyRing);
 
         final SimpleModule simpleModule = new SimpleModule();
         simpleModule.addSerializer(SecretKey.class,

--- a/core/src/test/java/io/aiven/kafka/tieredstorage/security/AesEncryptionProviderTest.java
+++ b/core/src/test/java/io/aiven/kafka/tieredstorage/security/AesEncryptionProviderTest.java
@@ -18,8 +18,6 @@ package io.aiven.kafka.tieredstorage.security;
 
 import javax.crypto.spec.SecretKeySpec;
 
-import java.util.Map;
-
 import io.aiven.kafka.tieredstorage.RsaKeyAwareTest;
 
 import org.junit.jupiter.api.Test;
@@ -27,8 +25,6 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AesEncryptionProviderTest extends RsaKeyAwareTest {
-    private static final String KEY_ENCRYPTION_KEY_ID = "static-key-id";
-
     @Test
     void keyAndAadMustBePresent() {
         final AesEncryptionProvider aesProvider = new AesEncryptionProvider();
@@ -54,9 +50,7 @@ public class AesEncryptionProviderTest extends RsaKeyAwareTest {
 
     @Test
     void decryptGeneratedKey() {
-        final var rsaEncryptionProvider = new RsaEncryptionProvider(
-            KEY_ENCRYPTION_KEY_ID,
-            Map.of(KEY_ENCRYPTION_KEY_ID, RsaKeyReader.read(publicKeyPem, privateKeyPem)));
+        final var rsaEncryptionProvider = new RsaEncryptionProvider(KEY_ENCRYPTION_KEY_ID, keyRing);
         final AesEncryptionProvider aesProvider = new AesEncryptionProvider();
         final var dataKey = aesProvider.createDataKeyAndAAD().dataKey;
         final var encryptedKey = rsaEncryptionProvider.encryptDataKey(dataKey.getEncoded());


### PR DESCRIPTION
This commit makes config working on RSA keyrings instead of single key. Instead of a single pair of public and private files, it's needed to provide:
1. The list of key pairs IDs: `encryption.key.pairs`.
2. For each ID, the public and private file: `encryption.key.pairs.ID.public.key.file` and `encryption.key.pairs.ID.private.key.file`. (See e.g. how Kafka Connect configures transformations).
3. The "active" ID that will be used for encryption: `encryption.key.pair.id`.

See `RemoteStorageManagerConfigTest` for examples.
